### PR TITLE
tcp connection to communicate with sensor in daemon mode

### DIFF
--- a/powerapi/actor/supervisor.py
+++ b/powerapi/actor/supervisor.py
@@ -106,6 +106,7 @@ class Supervisor:
             elif msg is None:
                 if actor.is_alive():
                     actor.terminate()
+                    print (actor)
                     raise FailConfigureError("Unable to configure the " + actor.name)
                 else:
                     raise CrashConfigureError("The " + actor.name + " crash during initialisation process")

--- a/powerapi/database/__init__.py
+++ b/powerapi/database/__init__.py
@@ -35,3 +35,4 @@ from powerapi.database.opentsdb import OpenTSDB, CantConnectToOpenTSDBException
 from powerapi.database.influxdb import InfluxDB, CantConnectToInfluxDBException
 from powerapi.database.prometheus_db import PrometheusDB
 from .socket_db import SocketDB
+from .tcp_db import IOTcpDB

--- a/powerapi/database/tcp_db.py
+++ b/powerapi/database/tcp_db.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2018, INRIA
+# Copyright (c) 2018, University of Lille
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import asyncio
+from queue import Queue, Empty
+from threading import Thread, Lock
+import socket
+
+from . import IterDB, BaseDB
+from powerapi.utils import JsonStream
+from powerapi.report import Report
+from powerapi.report_model import ReportModel
+
+
+BUFFER_SIZE = 4096
+SOCKET_TIMEOUT = 0.5
+
+class IOTcpDB(BaseDB):
+
+    def __init__(self, addr, port, input=False):
+        self.lock = Lock()
+        BaseDB.__init__(self)
+        self.asynchrone = True
+        
+        self.loop = asyncio.get_event_loop()
+        
+        self.addr = addr
+        self.port = port
+        self.server = None
+        self.clients = []
+        self.in_client = None
+        self.input = input
+        
+    async def connect(self):
+        if self.input:
+            # self.queue = Queue()
+            self.in_client = await asyncio.open_connection (host=self.addr, port=self.port)        
+        else:
+            # self.queue = Queue()
+            self.server = await asyncio.start_server(self.gen_server_callback(), host=self.addr, port=self.port, loop=self.loop)
+        
+    def stop(self):
+        if self.input:
+            self.client.close ()
+        else:
+            self.server.close()
+
+    def save(self, report: Report, report_model: ReportModel):
+        json = report.serialize ()
+        with self.lock:        
+            for i in range (0, len (self.clients)):
+                if (self.clients [i].is_closing ()):
+                    self.clients = self.clients [:i] + self.clients [i+1:]
+                else:
+                    self.clients [i].write (str (json).encode ())
+        
+    def save_many(self, reports, report_model):
+        print (reports)
+        for i in reports:
+            self.save (i, report_model)
+
+    def gen_server_callback(self):                
+        def callback(_, writer):
+            with self.lock:
+                self.clients = self.clients + [writer]
+            
+        return callback
+
+    def iter(self, report_model, stream_mode):
+        return IterInTcpDB (self.in_client, report_model, stream_mode)
+
+
+class IterInTcpDB(IterDB):
+
+    def __init__ (self, db, report_model, stream_mode):
+        IterDB.__init__ (self, None, report_model, stream_mode)
+        
+        self.db = db
+
+    def __aiter__(self):
+        """
+        """
+        return self
+        
+    async def __anext__ (self):
+        reader, writer = self.db
+        stream = JsonStream(reader)
+        try: 
+            json_str = await stream.read_json_object()
+            report = self.report_model.get_type().deserialize(self.report_model.from_json(json_str))
+            print (report, " ", json_str)
+            return report
+        except asyncio.TimeoutError:
+            return None
+        
+                

--- a/powerapi/puller/handlers.py
+++ b/powerapi/puller/handlers.py
@@ -60,7 +60,7 @@ class DBPullerThread(Thread):
 
     def _connect(self):
         try:
-            self.state.database.connect()
+            #self.state.database.connect()
             self.loop.run_until_complete(self.state.database.connect())
             self.state.database_it = self.state.database.iter(self.state.report_model, self.state.stream_mode)
 

--- a/powerapi/pusher/pusher_actor.py
+++ b/powerapi/pusher/pusher_actor.py
@@ -39,7 +39,7 @@ class PusherState(State):
     Contains in addition to State values :
       - The database interface
     """
-    def __init__(self, actor, database, report_model):
+    def __init__(self, actor, database, report_model, asynchrone = False):
         """
         :param BaseDB database: Database for saving data.
         """
@@ -53,6 +53,8 @@ class PusherState(State):
 
         #: (Dict): Buffer data.
         self.buffer = []
+
+        self.asynchrone = asynchrone
 
 
 class PusherActor(Actor):
@@ -74,7 +76,7 @@ class PusherActor(Actor):
         Actor.__init__(self, name, level_logger, timeout)
 
         #: (State): State of the actor.
-        self.state = PusherState(self, database, report_model)
+        self.state = PusherState(self, database, report_model, asynchrone=database.asynchrone)
         self.delay = delay
         self.max_size = max_size
 

--- a/powerapi/report/power_report.py
+++ b/powerapi/report/power_report.py
@@ -56,7 +56,7 @@ class PowerReport(Report):
         self.socket = socket
 
     def __repr__(self) -> str:
-        return 'PowerReport(%s, %s, %s, %d, %f, %s)' % (self.timestamp, self.sensor, self.target, self.socket, self.power, self.metadata)
+        return 'PowerReport(%s, %s, %s, %s, %f, %s)' % (self.timestamp, self.sensor, self.target, str(self.socket), self.power, self.metadata)
 
     @staticmethod
     def deserialize(data: Dict) -> PowerReport:


### PR DESCRIPTION
This pull request is associated with the pull request on hwpc-sensor. 
I added the daemon report (tcp server), on the sensor. 

Here I added client tcp to read from the sensor. And output tcp to write into a tcp server the result of the formula (power report, formula report).

So the new options are : 
- For input, 
    ``` --input tcp -U url -P port -m model -n name ```
- For output 
    ``` --output tcp -U url -P port -m model ```
 The output url is for accepted urls.

