### PR TITLE
Added support for influxdb2.0, using the influxdb-client module (as o…

### DIFF
--- a/Dockerfile-cpython
+++ b/Dockerfile-cpython
@@ -5,6 +5,6 @@ WORKDIR /opt/powerapi
 USER powerapi
 
 COPY --chown=powerapi . /tmp/powerapi
-RUN pip3 install --user --no-cache-dir "/tmp/powerapi[mongodb, influxdb, opentsdb, prometheus]" && rm -r /tmp/powerapi
+RUN pip3 install --user --no-cache-dir "/tmp/powerapi[mongodb, influxdb2 ,influxdb, opentsdb, prometheus]" && rm -r /tmp/powerapi
 
 ENTRYPOINT ["/bin/echo", "This Docker image should be used as a base for another image and should not be executed directly."]

--- a/Dockerfile-pypy
+++ b/Dockerfile-pypy
@@ -11,6 +11,6 @@ RUN cd /tmp/powerapi && \
     sed -i 's/from __future__ import annotations//g' $(find powerapi/ -name "*.py") && \
     sed -i 's/python_requires = >= 3\.[0-9]/python_requires = >= 3.6/g' setup.cfg
 
-RUN pypy3 -m pip install --user --no-cache-dir "/tmp/powerapi[mongodb, influxdb, opentsdb, prometheus]" && rm -r /tmp/powerapi
+RUN pypy3 -m pip install --user --no-cache-dir "/tmp/powerapi[mongodb, influxdb2, influxdb, opentsdb, prometheus]" && rm -r /tmp/powerapi
 
 ENTRYPOINT ["/bin/echo", "This Docker image should be used as a base for another image and should not be executed directly."]

--- a/powerapi/cli/parser.py
+++ b/powerapi/cli/parser.py
@@ -388,8 +388,8 @@ class MainParser(Parser):
                                   function of its argument is parsed
 
         """
-        print("Parsing arguments!")
-        print(args)
+        
+        
         try:
             args, _ = getopt.getopt(args, self.short_arg, self.long_arg)
         except getopt.GetoptError as exn:

--- a/powerapi/cli/parser.py
+++ b/powerapi/cli/parser.py
@@ -388,6 +388,8 @@ class MainParser(Parser):
                                   function of its argument is parsed
 
         """
+        print("Parsing arguments!")
+        print(args)
         try:
             args, _ = getopt.getopt(args, self.short_arg, self.long_arg)
         except getopt.GetoptError as exn:

--- a/powerapi/cli/tools.py
+++ b/powerapi/cli/tools.py
@@ -39,7 +39,7 @@ from powerapi.cli.parser import BadValueException, MissingValueException
 from powerapi.cli.parser import BadTypeException, BadContextException
 from powerapi.cli.parser import UnknowArgException
 from powerapi.report_model import HWPCModel, PowerModel, FormulaModel, ControlModel
-from powerapi.database import MongoDB, CsvDB, InfluxDB, OpenTSDB, SocketDB, PrometheusDB, DirectPrometheusDB, VirtioFSDB
+from powerapi.database import MongoDB, CsvDB, InfluxDB2 ,InfluxDB, OpenTSDB, SocketDB, PrometheusDB, DirectPrometheusDB, VirtioFSDB
 from powerapi.puller import PullerActor
 from powerapi.pusher import PusherActor
 from powerapi.report_modifier import LibvirtMapper
@@ -166,6 +166,20 @@ class CommonCLIParser(MainParser):
         subparser_influx_output.add_argument('n', 'name', help='specify pusher name', default='pusher_influxdb')
         self.add_actor_subparser('output', subparser_influx_output,
                                      help_str='specify a database input : --db_output database_name ARG1 ARG2 ... ')
+
+
+        subparser_influx2_output = ComponentSubParser('influxdb2')
+        subparser_influx2_output.add_argument('u', 'uri', help='specify InfluxDB2 uri. Examples: \'localhost\'')
+        subparser_influx2_output.add_argument('b', 'bucket', help='specify InfluxDB2 bucket name')
+        subparser_influx2_output.add_argument('p', 'port', help='specify InfluxDB2 connection port', type=int)
+        subparser_influx2_output.add_argument('t', 'token', help='specify the auth token to connect to InfluxDB2')
+        subparser_influx2_output.add_argument('o', 'org', help='specify the name of the organization used to connect to InfluxDB2')
+        subparser_influx2_output.add_argument('m', 'model', help='specify data type that will be stored in the database',
+                                             default='PowerReport')
+        subparser_influx2_output.add_argument('n', 'name', help='specify pusher name', default='pusher_influxdb2')
+        self.add_actor_subparser('output', subparser_influx2_output,
+                                     help_str='specify a database input : --db_output database_name ARG1 ARG2 ... ')
+
 
         subparser_opentsdb_output = ComponentSubParser('opentsdb')
         subparser_opentsdb_output.add_argument('u', 'uri', help='specify openTSDB host')
@@ -294,6 +308,7 @@ class DBActorGenerator(Generator):
             'direct_prom': lambda db_config: DirectPrometheusDB(db_config['port'], db_config['uri'], db_config['metric_name'],
                                                           db_config['metric_description'], self.model_factory[db_config['model']]),
             'virtiofs': lambda db_config: VirtioFSDB(db_config['vm_name_regexp'], db_config['root_directory_name'], db_config['vm_directory_name_prefix'], db_config['vm_directory_name_suffix']),
+            'influxdb2': lambda db_config: InfluxDB2( db_config['uri'], db_config["port"] , db_config["token"], db_config["org"] ,db_config["bucket"] ),
         }
 
     def remove_model_factory(self, model_name):

--- a/powerapi/database/__init__.py
+++ b/powerapi/database/__init__.py
@@ -36,4 +36,5 @@ from powerapi.database.influxdb import InfluxDB, CantConnectToInfluxDBException
 from powerapi.database.prometheus_db import PrometheusDB
 from powerapi.database.virtiofs_db import VirtioFSDB
 from powerapi.database.direct_prometheus_db import DirectPrometheusDB
+from powerapi.database.influxdb2 import InfluxDB2, CantConnectToInfluxDB2Exception
 from .socket_db import SocketDB

--- a/powerapi/database/influxdb2.py
+++ b/powerapi/database/influxdb2.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2018, INRIA
+# Copyright (c) 2018, University of Lille
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+import logging
+try:
+    from influxdb_client import InfluxDBClient
+    from influxdb_client.client.write_api import SYNCHRONOUS
+    #from influxdb import InfluxDBClient
+    from requests.exceptions import ConnectionError
+except ImportError:
+    logging.getLogger().info("influx_client is not installed.")
+
+from typing import List
+
+
+from powerapi.database import BaseDB, DBError
+
+from powerapi.report import Report
+from powerapi.report_model import ReportModel
+
+class CantConnectToInfluxDB2Exception(DBError):
+    pass
+
+
+class InfluxDB2(BaseDB):
+    """
+    MongoDB class herited from BaseDB
+
+    Allow to handle a InfluxDB database in reading or writing.
+    """
+
+    def __init__(self, uri: str, port: int, token: str, org: str, bucket: str):
+        """
+        :param str url:             URL of the InfluxDB server
+        :param int port:            port of the InfluxDB server
+
+        :param str db_name:         database name in the influxdb
+                                    (ex: "powerapi")
+        
+        :param str token            access token Needed to connect to the influxdb instance
+
+        :param str org              org that holds the data (??)
+        
+        :param str bucket           bucket where the data is going to be stored
+        
+        :param report_model:        XXXModel object. Allow to read specific
+                                    report with a specific format in a database
+        :type report_model:         powerapi.ReportModel
+
+        """
+        BaseDB.__init__(self)
+        self.uri = uri
+        self.port = port
+        self.complete_url ="http://%s:%s" %(   self.uri , str(self.port))
+        #self.db_name = db_name
+            
+        self.token=token
+        self.org = org
+        self.org_id = None
+        self.bucket = bucket
+
+        self.client = None
+        self.write_api= None
+
+    def _ping_client(self):
+        if hasattr(self.client, 'health'):
+            self.client.health()
+        else:
+            self.client.request(url="ping", method='GET', expected_response_code=204)
+
+    def connect(self):
+        """
+        Override from BaseDB.
+
+        Create the connection to the influxdb database with the current
+        configuration (hostname/port/db_name), then check if the connection has
+        been created without failure.
+
+        """
+
+        # close connection if reload
+        if self.client is not None:
+            self.client.close()
+        
+        self.client = InfluxDBClient(url=self.complete_url, token=self.token, org=self.org)
+        #self.client = InfluxDBClient(host=self.uri, port=self.port, database=self.db_name)
+        # retrieve the org_id
+        org_api = self.client.organizations_api()
+        
+        for org_response in  org_api.find_organizations():
+            if org_response.name==self.org:
+                self.org_id=org_response.id
+        
+        self.write_api = self.client.write_api(write_options=SYNCHRONOUS) 
+
+        try:
+            self._ping_client()
+        except ConnectionError:
+            raise CantConnectToInfluxDB2Exception('connexion error')
+         
+        # Not sure we need to keep the buckeapi object longer than this
+        bucket_api= self.client.buckets_api()
+        if bucket_api.find_bucket_by_name(self.bucket)== None:
+        #If we can't find the bucket, we create it.
+            bucket_api.create_bucket(bucket_name=self.bucket, org_id=self.org_id)
+     
+        # We need the org_id in order to create a bucket
+        #bucket_api.create_database(self.db_name, org_id="")
+    # TO DO
+    def save(self, report: Report, report_model: ReportModel):
+        """
+        Override from BaseDB
+
+        :param report: Report to save
+        :param report_model: ReportModel
+        """
+        ## Let's print the data to see its schema.
+        #print("printing report")
+        #print(report)
+        #print("Printing serialized report")
+        #print(report.serialize())
+        data = report_model.to_influxdb(report.serialize())
+        self.write_api.write(bucket= this.bucket, record= data)
+        #self.client.write_points([data])
+    # TO DO
+    def save_many(self, reports: List[Report], report_model: ReportModel):
+        """
+        Save a batch of data
+
+        :param reports: Batch of data.
+        :param report_model: ReportModel
+        """
+
+        data_list = list(map(lambda r: report_model.to_influxdb(r.serialize()), reports))
+        self.write_api.write(bucket= self.bucket, record= data_list)

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,8 @@ prometheus =
 docs =
     sphinx >=1.8.1
     sphinx-autodoc-typehints >=1.6.0
+influxdb2 =
+    influxdb-client >= 1.20.0
 
 [aliases]
 test = pytest


### PR DESCRIPTION
…pposed to the influxdb module) that implements v2 of the InlfuxdDB API. The command line flags needed to make use of this are:
```
--output influxdb2
--uri $URI
--port $PORT
--bucket $BUCKET
--name $PUSHERNAME
--org   $ORG
--token  $AUTH_TOKEN
```
the --name commandline flag is optional.
Tested the Dockerfile-cpython and it works. Haven't yet tested Dockerfile-pypy.