### PR TITLE
Avoid sys.exit in generators

### DIFF
--- a/powerapi/cli/tools.py
+++ b/powerapi/cli/tools.py
@@ -227,7 +227,7 @@ class Generator:
         """
         if self.component_group_name not in config:
             print('CONFIG error : no ' + self.component_group_name + ' specified', file=sys.stderr)
-            sys.exit()
+            raise PowerAPIException('CONFIG error : no ' + self.component_group_name + ' specified')
 
         actors = {}
 
@@ -239,7 +239,7 @@ class Generator:
                 msg = 'CONFIG error : argument ' + exn.args[0]
                 msg += ' needed with output ' + component_type
                 print(msg, file=sys.stderr)
-                sys.exit()
+                raise PowerAPIException(msg)
 
         return actors
 
@@ -362,7 +362,7 @@ class DBActorGenerator(Generator):
         if db_name not in self.db_factory:
             msg = 'CONFIG error : database type ' + db_name + 'unknow'
             print(msg, file=sys.stderr)
-            sys.exit()
+            raise PowerAPIException(msg)
         else:
             return self.db_factory[db_name](db_config)
 
@@ -370,7 +370,7 @@ class DBActorGenerator(Generator):
         if model_name not in self.model_factory:
             msg = 'CONFIG error : model type ' + model_name + 'unknow'
             print(msg, file=sys.stderr)
-            sys.exit()
+            raise PowerAPIException(msg)
         else:
             return self.model_factory[db_config['model']]
 


### PR DESCRIPTION
This PR is meant to fix #121

Generators might be called after some actors have already been created,
calling `sys.exit` quits without closing the actors system properly
with `supervisor.shutdown()`.

Actually, to fully fix #121 some extra change is required in smartwatt to catch the exception (in `__main__.py`) and call `supervisor.shutdown()`. 

I did not remove all call to `sys.exit`, the following calls are left:
* in the cli parser : these probably do not matter as nothing has been started yet when we parse the cli arguments
* in `Sync.add_report` (`sync.py` l.117) : I'm not sure about this one, I don't see where this class is used