### PR TITLE
Feat: allow other actor types

### DIFF
--- a/powerapi/actor.py
+++ b/powerapi/actor.py
@@ -175,7 +175,7 @@ class TimedActor(Actor):
     def receiveMsg_StartMessage(self, message: StartMessage, sender: ActorAddress):
         """
         When receiving a StartMessage, initialize the actor and set it into sleeping phase
-        ask the actor system to wake agter a given time period
+        ask the actor system to wake after a given time period
         """
         Actor.receiveMsg_StartMessage(self, message, sender)
         self.wakeupAfter(self._time_interval)

--- a/powerapi/dispatcher/dispatcher_actor.py
+++ b/powerapi/dispatcher/dispatcher_actor.py
@@ -56,7 +56,7 @@ def _clean_list(id_list):
 
 def _extract_formula_id(report: Report, dispatch_rule: DispatchRule, primary_dispatch_rule: DispatchRule) -> List[Tuple]:
     """
-    Use the dispatcha rule to extract formula_id from the given report.
+    Use the dispatch rule to extract formula_id from the given report.
     Formula id are then mapped to an identifier that match the primary
     report identifier fields
 

--- a/powerapi/supervisor.py
+++ b/powerapi/supervisor.py
@@ -121,7 +121,7 @@ class Supervisor:
         create an actor from a given class and send it a start message.
         :param actor_cls: class used to create the actor
         :param start_message: message used to initialize the actor
-        :raise InitializationException: if an error occurs during actor initialiszation process
+        :raise InitializationException: if an error occurs during actor initialization process
         """
         name = start_message.name
         address = self.system.createActor(actor_cls)

--- a/powerapi/supervisor.py
+++ b/powerapi/supervisor.py
@@ -142,8 +142,8 @@ class Supervisor:
             self.pullers[name] = address
         elif issubclass(actor_cls, DispatcherActor):
             self.dispatchers[name] = address
-        else:
-            raise AttributeError('Actor is not a DispatcherActor, PusherActor or PullerActor')
+        elif not issubclass(actor_cls, Actor):
+            raise AttributeError('Actor is not a PowerAPI Actor')
         self.actors[name] = address
 
     def _wait_actors(self):


### PR DESCRIPTION
When extending PowerAPI or developing a formula, it can be necessary to define actors that are not Pullers, Pushers or Dispatcher.

This PR also fixes a few typos in docstrings.
