### PR TITLE
feat: connection to influxdb2

### DIFF
--- a/Dockerfile-cpython
+++ b/Dockerfile-cpython
@@ -5,6 +5,6 @@ WORKDIR /opt/powerapi
 USER powerapi
 
 COPY --chown=powerapi . /tmp/powerapi
-RUN pip3 install --user --no-cache-dir "/tmp/powerapi[mongodb, influxdb, opentsdb, prometheus]" && rm -r /tmp/powerapi
+RUN pip3 install --user --no-cache-dir "/tmp/powerapi[mongodb, influxdb, influxdb2, opentsdb, prometheus]" && rm -r /tmp/powerapi
 
 ENTRYPOINT ["/bin/echo", "This Docker image should be used as a base for another image and should not be executed directly."]

--- a/Dockerfile-pypy
+++ b/Dockerfile-pypy
@@ -10,7 +10,7 @@ RUN cd /tmp/powerapi &&\
 	wget https://raw.githubusercontent.com/powerapi-ng/powerapi-ci-env/main/to_36.sh && \
 	/bin/bash to_36.sh powerapi
 
-RUN pypy3 -m pip install --user --no-cache-dir "/tmp/powerapi[mongodb, influxdb, opentsdb, prometheus]" && \
+RUN pypy3 -m pip install --user --no-cache-dir "/tmp/powerapi[mongodb, influxdb, influxdb2, opentsdb, prometheus]" && \
 	rm -r /tmp/powerapi
 
 ENTRYPOINT ["/bin/echo", "This Docker image should be used as a base for another image and should not be executed directly."]

--- a/powerapi/cli/generator.py
+++ b/powerapi/cli/generator.py
@@ -34,7 +34,7 @@ from typing import Dict, Tuple, Type
 from powerapi.actor import Actor
 from powerapi.exception import PowerAPIException
 from powerapi.report import HWPCReport, PowerReport, ControlReport, ProcfsReport
-from powerapi.database import MongoDB, CsvDB, InfluxDB, OpenTSDB, SocketDB, PrometheusDB, DirectPrometheusDB, VirtioFSDB, FileDB
+from powerapi.database import MongoDB, CsvDB, InfluxDB, InfluxDB2, OpenTSDB, SocketDB, PrometheusDB, DirectPrometheusDB, VirtioFSDB, FileDB
 from powerapi.puller import PullerActor
 from powerapi.pusher import PusherActor
 from powerapi.message import StartMessage, PusherStartMessage, PullerStartMessage
@@ -151,7 +151,8 @@ class DBActorGenerator(Generator):
                                                                 db_config['metric_description'], gen_tag_list(db_config)),
             'virtiofs': lambda db_config: VirtioFSDB(db_config['model'], db_config['vm_name_regexp'], db_config['root_directory_name'],
                                                      db_config['vm_directory_name_prefix'], db_config['vm_directory_name_suffix']),
-            'filedb': lambda db_config: FileDB(db_config['model'], db_config['filename'])
+            'filedb': lambda db_config: FileDB(db_config['model'], db_config['filename']),
+            'influxdb2': lambda db_config: InfluxDB2( db_config['model'], db_config['uri'], db_config["port"] , db_config["token"], db_config["org"] ,db_config["bucket"], gen_tag_list(db_config) ),
         }
 
     def remove_model_factory(self, model_name):

--- a/powerapi/cli/tools.py
+++ b/powerapi/cli/tools.py
@@ -166,6 +166,17 @@ class CommonCLIParser(MainConfigParser):
         subparser_influx_output.add_argument('n', 'name', help='specify pusher name', default='pusher_influxdb')
         self.add_subparser('output', subparser_influx_output,
                            help='specify a database output : --db_output database_name ARG1 ARG2 ... ')
+        
+        subparser_influx2_output = SubConfigParser('influxdb2')
+        subparser_influx2_output.add_argument('u', 'uri', help='specify InfluxDB2 uri. Examples: \'localhost\'')
+        subparser_influx2_output.add_argument('b', 'bucket', help='specify InfluxDB2 bucket name')
+        subparser_influx2_output.add_argument('p', 'port', help='specify InfluxDB2 connection port', type=int)
+        subparser_influx2_output.add_argument('t', 'token', help='specify the auth token to connect to InfluxDB2')
+        subparser_influx2_output.add_argument('o', 'org', help='specify the name of the organization used to connect to InfluxDB2')
+        subparser_influx2_output.add_argument('m', 'model', help='specify data type that will be stored in the database', default='PowerReport')
+        subparser_influx2_output.add_argument('n', 'name', help='specify pusher name', default='pusher_influxdb2')
+        self.add_subparser('output', subparser_influx2_output,
+                                     help='specify a database input : --db_output database_name ARG1 ARG2 ... ')
 
         subparser_opentsdb_output = SubConfigParser('opentsdb')
         subparser_opentsdb_output.add_argument('u', 'uri', help='specify openTSDB host')

--- a/powerapi/database/__init__.py
+++ b/powerapi/database/__init__.py
@@ -37,3 +37,4 @@ from powerapi.database.virtiofs_db import VirtioFSDB
 from powerapi.database.direct_prometheus_db import DirectPrometheusDB
 from powerapi.database.socket_db import SocketDB
 from powerapi.database.file_db import FileDB
+from powerapi.database.influxdb2 import InfluxDB2, CantConnectToInfluxDB2Exception

--- a/powerapi/database/influxdb2.py
+++ b/powerapi/database/influxdb2.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2018, INRIA
+# Copyright (c) 2018, University of Lille
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+import logging
+try:
+    from influxdb_client import InfluxDBClient
+    from influxdb_client.client.write_api import SYNCHRONOUS
+    from requests.exceptions import ConnectionError
+except ImportError:
+    logging.getLogger().info("influx_client is not installed.")
+
+from typing import List, Type
+
+
+from powerapi.database import BaseDB, DBError
+
+from powerapi.report import Report
+
+class CantConnectToInfluxDB2Exception(DBError):
+    pass
+
+
+class InfluxDB2(BaseDB):
+    """
+    MongoDB class herited from BaseDB
+
+    Allow to handle a InfluxDB database in reading or writing.
+    """
+
+    def __init__(self, report_type: Type[Report], uri: str, port: int, token: str, org: str, bucket: str, tags: List[str]):
+        """
+        :param report_type:        Type of the report handled by this database
+
+        :param str uri:             URL of the InfluxDB server
+        :param int port:            port of the InfluxDB server
+        
+        :param str token            access token Needed to connect to the influxdb instance
+
+        :param str org              org that holds the data
+        
+        :param str bucket           bucket where the data is going to be stored
+        
+        :param tags: metadata used to tag metric
+
+        """
+        BaseDB.__init__(self, report_type)
+        self.uri = uri
+        self.port = port
+        self.complete_url ="http://%s:%s" %(self.uri , str(self.port))
+            
+        self.token=token
+        self.org = org
+        self.org_id = None
+        self.bucket = bucket
+
+        self.client = None
+        self.write_api= None
+        self.tags = tags
+
+    def _ping_client(self):
+        if hasattr(self.client, 'health'):
+            self.client.health()
+        else:
+            self.client.request(url="ping", method='GET', expected_response_code=204)
+
+    def connect(self):
+        """
+        Override from BaseDB.
+
+        Create the connection to the influxdb database with the current
+        configuration (hostname/port/db_name), then check if the connection has
+        been created without failure.
+
+        """
+
+        # close connection if reload
+        if self.client is not None:
+            self.client.close()
+        
+        self.client = InfluxDBClient(url=self.complete_url, token=self.token, org=self.org)
+        # retrieve the org_id
+        org_api = self.client.organizations_api()
+        
+        for org_response in  org_api.find_organizations():
+            if org_response.name==self.org:
+                self.org_id=org_response.id
+        
+        self.write_api = self.client.write_api(write_options=SYNCHRONOUS) 
+
+        try:
+            self._ping_client()
+        except ConnectionError:
+            raise CantConnectToInfluxDB2Exception('connexion error')
+        
+        bucket_api=self.client.buckets_api()
+        if bucket_api.find_bucket_by_name(self.bucket)==None:
+            #If we can't find the bucket, we create it.
+            bucket_api.create_bucket(bucket_name=self.bucket, org_id=self.org_id)
+
+    def save(self, report: Report):
+        """
+        Override from BaseDB
+
+        :param report: Report to save
+        """
+
+        data = self.report_type.to_influxdb2(report, self.tags)
+        self.write_api.write(bucket=self.bucket, org=self.org, record=data)
+        
+    def save_many(self, reports: List[Report]):
+        """
+        Save a batch of data
+
+        :param reports: Batch of data.
+        """
+
+        data_list = list(map(lambda r: self.report_type.to_influxdb(r, self.tags), reports))
+        self.write_api.write(bucket=self.bucket, record=data_list)

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,8 @@ docs =
     sphinx-autodoc-typehints >=1.6.0
 modin =
     modin >= 0.14.1
+influxdb2 =
+    influxdb-client >= 1.20.0
 
 [aliases]
 test = pytest


### PR DESCRIPTION
Add support for influxdb 2 using influxdb_client,
The flags are the following
`
--uri $INFLUXDB_URI
--port $INFLUXDB_PORT
--token $INFLUXDB_TOKEN
--org $INFLUXDB_ORG
--bucket $INFLUXDB_BUCKET
--name $PUSHER_NAME
--model $DATA_TYPE
`
both model and name are optional
Based on the work of @jorgermurillo for the PR #116 