### PR TITLE
refactor: Fix pylint `unspecified-encoding` warnings

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -83,8 +83,7 @@ disable=raw-checker-failed,
         invalid-overridden-method,
         abstract-method,
         protected-access,
-        broad-exception-caught,
-        unspecified-encoding
+        broad-exception-caught
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/src/powerapi/cli/config_parser.py
+++ b/src/powerapi/cli/config_parser.py
@@ -26,6 +26,7 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 import getopt
 import json
 import os
@@ -496,7 +497,7 @@ class RootConfigParser(BaseConfigParser):
         Return a configuration dict that has all the arguments' names in the long form.
         If an argument does not exist, a UnknownArgException is raised
         """
-        with open(file_name, 'r') as config_file:
+        with open(file_name, 'r', encoding='utf-8') as config_file:
             conf = json.load(config_file)
             return self.normalize_configuration(conf=conf)
 

--- a/src/powerapi/database/csvdb.py
+++ b/src/powerapi/database/csvdb.py
@@ -90,7 +90,7 @@ class CsvIterDB(IterDB):
         # Open all files with csv and read first line
         for filename in self.filenames:
             try:
-                self.tmp_read[filename]['file'] = open(filename)
+                self.tmp_read[filename]['file'] = open(filename, 'r', encoding='utf-8')
                 self.tmp_read[filename]['reader'] = csv.DictReader(self.tmp_read[filename]['file'])
             except FileNotFoundError as error:
                 raise CsvBadFilePathError(error) from error
@@ -274,7 +274,7 @@ class CsvDB(BaseDB):
         for filename, values in data.items():
             output_filename = f'{rep_path}/{filename}.csv'
 
-            with open(output_filename, 'r+') as csvfile:
+            with open(output_filename, 'r+', encoding='utf-8') as csvfile:
                 expected_header = fixed_header + sorted(set(values[0].keys()) - set(fixed_header))
                 header_exist = False
 

--- a/src/powerapi/database/file_db.py
+++ b/src/powerapi/database/file_db.py
@@ -71,7 +71,7 @@ class FileIterDB(IterDB):
         :raise: StopIteration in stream mode when no report was found.
         """
 
-        with open(self.filename, "r") as file_object:
+        with open(self.filename, 'r', encoding='utf-8') as file_object:
             json_str = file_object.read()
 
             if json_str is None:
@@ -134,7 +134,7 @@ class FileDB(BaseDB):
 
         final_dict = {"PowerReport": [line]}
 
-        with open(self.filename, "w") as file_object:
+        with open(self.filename, 'w', encoding='utf-8') as file_object:
             file_object.write(str(final_dict))
 
     def save_many(self, reports: List[Report]):

--- a/src/powerapi/database/virtiofs_db.py
+++ b/src/powerapi/database/virtiofs_db.py
@@ -89,7 +89,7 @@ class VirtioFSDB(BaseDB):
         if not os.path.exists(vm_filename_path):
             raise DirectoryDoesNotExistForVirtioFS(vm_filename_path)
 
-        with open(vm_filename_path + vm_filename, 'w') as vm_file:
+        with open(vm_filename_path + vm_filename, 'w', encoding='utf-8') as vm_file:
             vm_file.write(str(power))
 
     def save_many(self, reports: List[Report]):

--- a/tests/utils/cli/base_config_parser.py
+++ b/tests/utils/cli/base_config_parser.py
@@ -40,7 +40,7 @@ def load_configuration_from_json_file(file_name: str) -> dict:
     """
     configuration = {}
     path = parent_module.__path__[0]
-    with open(path + '/' + file_name, 'r') as json_file:
+    with open(path + '/' + file_name, 'r', encoding='utf-8') as json_file:
         configuration = json.load(json_file)
     return configuration
 

--- a/tests/utils/report/hwpc.py
+++ b/tests/utils/report/hwpc.py
@@ -41,7 +41,7 @@ def extract_rapl_reports_with_2_sockets(number_of_reports: int) -> List[Dict]:
     :return: a list of reports. Each reports is a json dictionary
     """
     path = parent_module.__path__[0]
-    with open(f"{path}/hwpc_rapl_2_socket.json", "r") as json_file:
+    with open(f'{path}/hwpc_rapl_2_socket.json', 'r', encoding='utf-8') as json_file:
         reports = json.load(json_file)
         return reports['reports'][:number_of_reports]
 
@@ -61,7 +61,7 @@ def extract_all_events_reports_with_2_sockets(number_of_reports: int) -> List[Di
     :return: a list of reports. Each reports is a json dictionary
     """
     path = parent_module.__path__[0]
-    with open(f"{path}/hwpc_all_events_2_socket.json", "r") as json_file:
+    with open(f'{path}/hwpc_all_events_2_socket.json', 'r', encoding='utf-8') as json_file:
         reports = json.load(json_file)
         return reports['reports'][:number_of_reports]
 
@@ -85,7 +85,7 @@ def extract_all_events_reports_with_vm_name(number_of_reports: int) -> List[Dict
     :return: a list of reports. Each reports is a json dictionary. Only reports with vm name as target is returned
     """
     path = parent_module.__path__[0]
-    with open(f"{path}/hwpc_all_vm_target.json", "r") as json_file:
+    with open(f'{path}/hwpc_all_vm_target.json', 'r', encoding='utf-8') as json_file:
         reports = json.load(json_file)
         return list(filter(lambda r: r['target'] == LIBVIRT_TARGET_NAME1 or r['target'] == LIBVIRT_TARGET_NAME2, reports['reports']))[:number_of_reports]
 
@@ -96,6 +96,6 @@ def gen_HWPCReports(number_of_reports: int) -> List[HWPCReport]:
     :return: a list of HWPCReport
     """
     path = parent_module.__path__[0]
-    with open(f"{path}/hwpc.json", "r") as json_file:
+    with open(f'{path}/hwpc.json', 'r', encoding='utf-8') as json_file:
         reports = list(map(HWPCReport.from_json, json.load(json_file)['reports']))
         return reports[:number_of_reports]


### PR DESCRIPTION
This PR re-enable pylint `unspecified-encoding` check and fixes triggered warnings in the codebase.