### PR TITLE
refactor: Fix pylint `protected-access` warnings

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -80,7 +80,6 @@ disable=raw-checker-failed,
         dangerous-default-value,
         invalid-overridden-method,
         abstract-method,
-        protected-access,
         broad-exception-caught
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/src/powerapi/report/power_report.py
+++ b/src/powerapi/report/power_report.py
@@ -151,10 +151,11 @@ class PowerReport(Report):
         power = report.power
         return filename, power
 
-    def _gen_tag(self, metadata_kept):
-        tags = {'sensor': self.sensor,
-                'target': self.target
-                }
+    def gen_tag(self, metadata_kept):
+        """
+        Generate the tags list of the report.
+        """
+        tags = {'sensor': self.sensor, 'target': self.target}
 
         for metadata_name in metadata_kept:
             if metadata_name not in self.metadata:
@@ -170,7 +171,7 @@ class PowerReport(Report):
         """
         return {
             'measurement': 'power_consumption',
-            'tags': report._gen_tag(tags),
+            'tags': report.gen_tag(tags),
             'time': str(report.timestamp),
             'fields': {
                 'power': report.power
@@ -183,7 +184,7 @@ class PowerReport(Report):
         :return: a dictionary, that can be stored into a prometheus instance, from a given PowerReport
         """
         return {
-            'tags': report._gen_tag(tags),
+            'tags': report.gen_tag(tags),
             'time': int(report.timestamp.timestamp()),
             'value': report.power
         }

--- a/src/powerapi/utils/tree.py
+++ b/src/powerapi/utils/tree.py
@@ -173,8 +173,8 @@ class Node:
         aux(self, 1)
 
     def retrieve_leaf_values(self, path):
-        """retrieves all leafs value under the node designating by path
-
+        """
+        Retrieves all leafs value under the node designating by path
         :param path:
         :type path: list
         :rtype: list : list of leafs value
@@ -186,26 +186,25 @@ class Node:
                 return []
             # if the current node is a leaf return its value
             if depth == (len(path) - 1):
-                return node._get_leafs()
+                return node.get_leafs()
 
             # go down in all child nodes
             return reduce(lambda acc, child: acc + aux(child, depth + 1), node.childs, [])
         return aux(self, 0)
 
-    def _get_leafs(self):
+    def get_leafs(self):
         """
-        Retrives all leafs under this node
+        Retrieves all leafs under this node.
         """
         if self.is_leaf:
             return [self.val]
         # concat all leafs value of the node's childs
-        return reduce(lambda acc, child: acc + child._get_leafs(), self.childs,
-                      [])
+        return reduce(lambda acc, child: acc + child.get_leafs(), self.childs, [])
 
     def __eq__(self, other):
         if not isinstance(other, Node):
             return False
-        if (self.label != other.label or self.val != other.val or self.is_leaf != other.is_leaf):
+        if self.label != other.label or self.val != other.val or self.is_leaf != other.is_leaf:
             return False
         sorted_child = deepcopy(self.childs)
         sorted_child.sort(key=lambda node: node.label)


### PR DESCRIPTION
This PR re-enable pylint `protected-access` check and fixes the triggered warnings in the codebase.