### PR TITLE
test: Fix queue deadlock when terminating actors

### DIFF
--- a/tests/utils/db/db.py
+++ b/tests/utils/db/db.py
@@ -26,7 +26,7 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-from multiprocessing import Queue
+from multiprocessing import Manager
 
 from powerapi.database import BaseDB, DBError
 from powerapi.report import Report
@@ -60,7 +60,9 @@ class FakeDB(BaseDB):
     def __init__(self, content=[]):
         BaseDB.__init__(self, Report, [FakeDBError])
         self._content = content
-        self.q = Queue()
+
+        self.manager = Manager()
+        self.q = self.manager.Queue()
 
     def connect(self):
         self.q.put('connected', block=False)
@@ -83,7 +85,9 @@ class SilentFakeDB(BaseDB):
     def __init__(self, content=[]):
         BaseDB.__init__(self, Report)
         self._content = content
-        self.q = Queue()
+
+        self.manager = Manager()
+        self.q = self.manager.Queue()
 
     def connect(self):
         pass

--- a/tests/utils/dispatcher/dispatcher.py
+++ b/tests/utils/dispatcher/dispatcher.py
@@ -27,7 +27,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from multiprocessing import Queue
+from multiprocessing import Manager
 
 from powerapi.dispatcher import DispatcherActor, RouteTable
 
@@ -39,8 +39,10 @@ class FakeDispatcher(DispatcherActor):
 
     def __init__(self, name: str):
         super().__init__(name, lambda *args: None, [], RouteTable())
-        self.control_mailbox = Queue()
-        self.data_mailbox = Queue()
+
+        self.manager = Manager()
+        self.control_mailbox = self.manager.Queue()
+        self.data_mailbox = self.manager.Queue()
 
     def run(self) -> None:
         return


### PR DESCRIPTION
This PR fixes some deadlocks happening sometimes when using the `FakeDispatcher` and `FakeDB` in tests.