### PR TITLE
fix: create CSV output file when it doesn't exists

### DIFF
--- a/src/powerapi/database/csvdb.py
+++ b/src/powerapi/database/csvdb.py
@@ -277,14 +277,12 @@ class CsvDB(BaseDB):
                 expected_header = fixed_header + sorted(set(values[0].keys()) - set(fixed_header))
                 header_exist = False
 
+                csvfile.seek(0)  # Go to beginning of file before reading
                 reader = csv.DictReader(csvfile)
                 if reader.fieldnames:
                     header_exist = True
                     if reader.fieldnames != expected_header:
                         raise HeaderAreNotTheSameError(f"Header are not the same in {output_filename}")
-
-                # Go to EOF before writing rows
-                csvfile.seek(0, 2)
 
                 writer = csv.DictWriter(csvfile, fieldnames=expected_header)
                 if not header_exist:

--- a/src/powerapi/database/csvdb.py
+++ b/src/powerapi/database/csvdb.py
@@ -273,7 +273,7 @@ class CsvDB(BaseDB):
         for filename, values in data.items():
             output_filename = f'{rep_path}/{filename}.csv'
 
-            with open(output_filename, 'r+', encoding='utf-8') as csvfile:
+            with open(output_filename, 'a+', encoding='utf-8') as csvfile:
                 expected_header = fixed_header + sorted(set(values[0].keys()) - set(fixed_header))
                 header_exist = False
 


### PR DESCRIPTION
This PR fixes the issue #298. When a new target is detected CSV pusher fails because it tries to open a non existent CSV file. Now it creates the file if it doesn't exists.