### PR TITLE
fix(puller): Set database puller thread as daemon

### DIFF
--- a/src/powerapi/puller/handlers.py
+++ b/src/powerapi/puller/handlers.py
@@ -55,7 +55,7 @@ class DBPullerThread(Thread):
     """
 
     def __init__(self, state, timeout, handler):
-        Thread.__init__(self)
+        Thread.__init__(self, daemon=True)
         self.timeout = timeout
         self.state = state
         self.loop = None


### PR DESCRIPTION
This PR fixes a bug blocking the puller actor shutdown when its database puller thread is not stopping correctly.