### PR TITLE
refactor: Fix pylint warnings

### DIFF
--- a/src/powerapi/actor/socket_interface.py
+++ b/src/powerapi/actor/socket_interface.py
@@ -154,16 +154,12 @@ class SocketInterface:
         :return: the list of received messages or None if timeout
         :rtype: a list of Object or None
         """
-        events = self.poller.poll(self.timeout)
+        events = dict(self.poller.poll(self.timeout))
 
-        # If there is data available on both sockets, the control one has priority
-        if len(events) == 2:
-            return self._recv_serialized(self.control_socket)
+        if len(events) == 0:
+            return None
 
-        if len(events) == 1:
-            return self._recv_serialized(events[0][0])
-
-        return None
+        return self._recv_serialized(next(iter(events)))
 
     def receive_control(self, timeout):
         """

--- a/src/powerapi/pusher/handlers.py
+++ b/src/powerapi/pusher/handlers.py
@@ -49,7 +49,6 @@ class PusherStartHandler(StartHandler):
         except DBError as error:
             self.state.actor.send_control(ErrorMessage(self.state.actor.name, error.msg))
             self.state.alive = False
-            return
 
 
 class PusherPoisonPillMessageHandler(PoisonPillMessageHandler):


### PR DESCRIPTION
This PR fixes the warnings raised by the latest version of pylint about code in the `pusher` and `actor` modules.