### PR TITLE
ci(release): Enable generation and upload of python package digital attestation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,7 @@ jobs:
       uses: pypa/gh-action-pypi-publish@8a08d616893759ef8e1aa1f2785787c0b97e20d6 # v1.10.0
       with:
         print-hash: true
+        attestations: true
 
   docker-image:
     name: Publish Docker image


### PR DESCRIPTION
Enable the generation and upload of the digital attestation for the generated python package to the PyPI.org index.

For more information about the PEP 740 : https://peps.python.org/pep-0740/