### PR TITLE
build: Improve development dependencies handling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,22 +25,24 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Install uv
+      uses: astral-sh/setup-uv@b5f58b2abc5763ade55e4e9d0fe52cd1ff7979ca # v5.2.1
+
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install -e ".[devel]"
+        uv sync --extra everything --dev
 
     - name: Lint with flake8
       run: |
-        flake8 --count --show-source --statistics src/ tests/
+        uv run flake8 --count --show-source --statistics src/ tests/
 
     - name: Static code analysis with pylint
       run: |
-        pylint src/ tests/
+        uv run pylint src/ tests/
 
     - name: Test with pytest
       run: |
-        pytest --cov=powerapi --cov-report=term --cov-report=xml tests/unit
+        uv run pytest --cov=powerapi --cov-report=term --cov-report=xml tests/unit
 
     - name: Upload coverage reports to Codecov
       if: ${{ matrix.python-version }} == "3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,21 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Databases:
+mongodb = ["pymongo >= 3.7.2"]
+influxdb = ["influxdb-client >= 1.30.0"]
+opentsdb = ["opentsdb-py >= 0.6.0"]
+prometheus = ["prometheus-client >= 0.9.0"]
+
+# Plaforms:
+kubernetes = ["kubernetes >= 27.0.2"]
+
+# Aliases:
+all-databases = ["powerapi[mongodb, influxdb, opentsdb, prometheus]"]
+all-platforms = ["powerapi[kubernetes]"]
+everything = ["powerapi[all-databases, all-platforms]"]
+
+[dependency-groups]
 test = [
     "pytest >= 7.0.1",
     "pytest-timeout >= 1.4.2",
@@ -50,20 +65,11 @@ lint = [
     "pylint >= 2.16.0"
 ]
 
-# Databases:
-mongodb = ["pymongo >= 3.7.2"]
-influxdb = ["influxdb-client >= 1.30.0"]
-opentsdb = ["opentsdb-py >= 0.6.0"]
-prometheus = ["prometheus-client >= 0.9.0"]
-
-# Plaforms:
-kubernetes = ["kubernetes >= 27.0.2"]
-
-# Aliases:
-all-databases = ["powerapi[mongodb, influxdb, opentsdb, prometheus]"]
-all-platforms = ["powerapi[kubernetes]"]
-everything = ["powerapi[all-databases, all-platforms]"]
-devel = ["powerapi[everything, test, docs, lint]"]
+dev = [
+    {include-group = 'test'},
+    {include-group = 'docs'},
+    {include-group = 'lint'}
+]
 
 [project.urls]
 homepage = "https://powerapi.org"
@@ -72,4 +78,3 @@ repository = "https://github.com/powerapi-ng/powerapi"
 
 [tool.setuptools.dynamic]
 version = {attr = "powerapi.__version__"}
-


### PR DESCRIPTION
This PR modifies the way development dependencies are managed in the project:
- Switch to `dependency-groups` [(PEP-735)](https://packaging.python.org/en/latest/specifications/dependency-groups/#dependency-groups) to manage the development dependencies in pyproject.toml ;
- Use `uv` to install the dependencies in the CI build workflow.