### PR TITLE
ci: Add `ruff` linter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,15 +32,19 @@ jobs:
       run: |
         uv sync --extra everything --dev
 
-    - name: Lint with flake8
+    - name: Run flake8
       run: |
         uv run flake8 --count --show-source --statistics src/ tests/
 
-    - name: Static code analysis with pylint
+    - name: Run pylint
       run: |
         uv run pylint src/ tests/
 
-    - name: Test with pytest
+    - name: Run ruff
+      run: |
+        uv run ruff check --output-format=github src/ tests/
+
+    - name: Run unit tests with coverage
       run: |
         uv run pytest --cov=powerapi --cov-report=term --cov-report=xml tests/unit
 

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,46 @@
+target-version = "py310"  # should match minimal python version of PowerAPI
+
+[lint]
+select = [
+    "F",   # pyflakes
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "B",   # flake8-bugbear
+    "G",   # flake8-logging-format
+    "PT",  # flake8-pytest-style
+    "UP",  # pyupgrade
+    "ERA", # eradicate
+    "RUF", # ruff
+]
+
+ignore = [
+    "E501",   # line too long
+
+    "UP006",  # non-pep585-annotation
+    "UP007",  # non-pep604-annotation-union
+    "UP015",  # redundant-open-modes
+    "UP031",  # printf-string-formatting
+    "UP035",  # deprecated-import
+    "B006",   # mutable-argument-default
+    "B008",   # function-call-in-default-argument
+    "F401",   # unused-import
+    "ERA001", # commented-out-code
+    "G003",   # logging-string-concat
+    "G004",   # logging-f-string
+    "RUF005", # collection-literal-concatenation
+    "RUF013", # implicit-optional
+    "RUF015", # unnecessary-iterable-allocation-for-first-element
+
+    "UP026",  # deprecated-mock-import
+    "B005",   # strip-with-multi-characters
+    "B010",   # set-attr-with-constant
+    "B011",   # assert-false
+    "B017",   # assert-raises-exception
+    "B905",   # zip-without-explicit-strict
+    "E721",   # type-comparison
+    "PT001",  # pytest-fixture-incorrect-parentheses-style
+    "PT011",  # pytest-raises-too-broad
+    "PT012",  # pytest-raises-with-multiple-statements
+    "PT015",  # pytest-assert-always-false
+    "PT022",  # pytest-useless-yield-fixture
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,8 @@ docs = [
 
 lint = [
     "flake8 >= 3.9.2",
-    "pylint >= 2.16.0"
+    "pylint >= 2.16.0",
+    "ruff >= 0.9.6"
 ]
 
 dev = [


### PR DESCRIPTION
This PR adds the [Ruff](https://docs.astral.sh/ruff/) linter configuration file and enable checks in GitHub actions `build` workflow.