### PR TITLE
refactor: Use PEP-604 annotations for union types

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -15,8 +15,7 @@ select = [
 
 ignore = [
     "E501",   # line too long
-
-    "UP007",  # non-pep604-annotation-union
+    
     "UP015",  # redundant-open-modes
     "UP031",  # printf-string-formatting
     "UP035",  # deprecated-import

--- a/src/powerapi/dispatch_rule/dispatch_rule.py
+++ b/src/powerapi/dispatch_rule/dispatch_rule.py
@@ -27,14 +27,12 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from typing import Optional
-
 
 class DispatchRule:
     """
     Group by rule
     """
-    def __init__(self, primary: bool = False, fields: Optional[list[str]] = None):
+    def __init__(self, primary: bool = False, fields: list[str] | None = None):
         self.is_primary = primary
         self.fields = fields
 

--- a/src/powerapi/processor/pre/k8s/metadata_cache_manager.py
+++ b/src/powerapi/processor/pre/k8s/metadata_cache_manager.py
@@ -29,7 +29,6 @@
 
 from dataclasses import dataclass
 from multiprocessing import Manager
-from typing import Optional
 
 ADDED_EVENT = 'ADDED'
 DELETED_EVENT = 'DELETED'
@@ -70,7 +69,7 @@ class K8sMetadataCacheManager:
         if event == DELETED_EVENT:
             self.metadata_cache.pop(container_metadata.container_id, None)
 
-    def get_container_metadata(self, container_id: str) -> Optional[K8sContainerMetadata]:
+    def get_container_metadata(self, container_id: str) -> K8sContainerMetadata | None:
         """
         Get metadata for a specific container from the cache.
         :param container_id: Container ID (hexadecimal string of 64 characters, short format is not supported)

--- a/src/powerapi/processor/pre/k8s/monitor_agent.py
+++ b/src/powerapi/processor/pre/k8s/monitor_agent.py
@@ -31,7 +31,6 @@ import logging
 import sys
 from multiprocessing import Process
 from signal import signal, SIGTERM, SIGINT
-from typing import Optional
 
 from kubernetes import client, config, watch
 from kubernetes.client import V1Pod, V1PodList, V1ContainerStatus
@@ -185,7 +184,7 @@ class K8sMonitorAgent(Process):
             for container_id, container_name in self.get_containers_id_name_from_statuses(container_statuses).items()
         ]
 
-    def fetch_list_all_pod_for_all_namespaces(self) -> Optional[int]:
+    def fetch_list_all_pod_for_all_namespaces(self) -> int | None:
         """
         Fetch all pod for all namespaces and populate the metadata cache.
         :return: Resource version of the last fetched entry


### PR DESCRIPTION
[PEP 604 – Allow writing union types as `X | Y`](https://peps.python.org/pep-0604/)