### PR TITLE
fix(report/hwpc): Raise `BadInputData` exception when csv line is incomplete

### DIFF
--- a/src/powerapi/report/hwpc_report.py
+++ b/src/powerapi/report/hwpc_report.py
@@ -156,6 +156,10 @@ class HWPCReport(Report):
                     if timestamp != HWPCReport._extract_timestamp(row[TIMESTAMP_KEY]):
                         raise BadInputData('csv line with different timestamp are mixed into one report', row)
 
+                for _, value in row.items():
+                    if not value:
+                        raise BadInputData('csv line incomplete', row)
+
                 HWPCReport._create_group(row, groups, group_name)
 
             except KeyError as exn:

--- a/tests/unit/report/test_hwpc_report.py
+++ b/tests/unit/report/test_hwpc_report.py
@@ -149,6 +149,17 @@ def test_create_hwpc_report_from_csv_without_socket_field_raise_BadInputData():
         _ = HWPCReport.from_csv_lines(csv_lines)
 
 
+def test_create_hwpc_report_from_csv_without_some_values_raise_BadInputData():
+    csv_lines = [('rapl',
+                  {'sensor': 'toto', 'timestamp': '1970-09-01T09:09:09.543', 'target': 'all', 'socket': '0', 'cpu': '7',
+                   'RAPL_VALUE': None}),
+                 ('rapl',
+                  {'sensor': 'toto', 'timestamp': '1970-09-01T09:09:09.543', 'target': 'all', 'socket': '1', 'cpu': '7',
+                   'RAPL_VALUE': None})]
+    with pytest.raises(BadInputData):
+        _ = HWPCReport.from_csv_lines(csv_lines)
+
+
 ############
 # EVENTS   #
 ############


### PR DESCRIPTION
Adding verification of rows values when creating HWPC reports in order to raise an exception when CSV files are no complete.