### PR TITLE
fix(database/opentsdb): Add timezone info to timestamp before sending to OpenTSDB

### DIFF
--- a/src/powerapi/database/opentsdb/opentsdb.py
+++ b/src/powerapi/database/opentsdb/opentsdb.py
@@ -28,6 +28,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import logging
+from datetime import timezone
 try:
     from opentsdb import TSDBClient
 except ImportError:
@@ -101,8 +102,8 @@ class OpenTSDB(BaseDB):
 
         :param report: Report to save
         """
-        self.client.send(self.metric_name, report.power, timestamp=int(report.timestamp.timestamp()),
-                         host=report.target)
+        self.client.send(self.metric_name, report.power,
+                         timestamp=int(report.timestamp.replace(tzinfo=timezone.utc).timestamp()), host=report.target)
 
     def save_many(self, reports: list[Report]):
         """


### PR DESCRIPTION
Timestamps from PowerReports are changed when sending data to OpenTSDB, as they are converted to a POSIX time taking into account the local timezone (system timezone). Now timezone info is added to the timestamps before conversion, indicating that they correspond to timezone UTC+00:00.

Fixes #563 