### PR TITLE
refactor: Use iterator to get first element of collections

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -20,7 +20,6 @@ ignore = [
     "B008",   # function-call-in-default-argument
     "F401",   # unused-import
     "RUF013", # implicit-optional
-    "RUF015", # unnecessary-iterable-allocation-for-first-element
 
     "B010",   # set-attr-with-constant
     "B905",   # zip-without-explicit-strict

--- a/src/powerapi/dispatch_rule/hwpc_dispatch_rule.py
+++ b/src/powerapi/dispatch_rule/hwpc_dispatch_rule.py
@@ -98,7 +98,7 @@ def _number_of_core_per_socket(group):
     :type group: Dict
     :rtype: int : the number of core per socket in this group
     """
-    return len(list(group.values())[0])
+    return len(next(iter(group.values())))
 
 
 def _extract_non_shared_group(report):


### PR DESCRIPTION
[unnecessary-iterable-allocation-for-first-element](https://docs.astral.sh/ruff/rules/unnecessary-iterable-allocation-for-first-element/#unnecessary-iterable-allocation-for-first-element-ruf015)