### PR TITLE
refactor: Force error when `zip` iterables have different lengths

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -17,12 +17,10 @@ ignore = [
     "E501",   # line too long
     
     "B006",   # mutable-argument-default
-    # "B008",   # function-call-in-default-argument
     "F401",   # unused-import
     "RUF013", # implicit-optional
 
     "B010",   # set-attr-with-constant
-    "B905",   # zip-without-explicit-strict
     "PT001",  # pytest-fixture-incorrect-parentheses-style
     "PT011",  # pytest-raises-too-broad
     "PT012",  # pytest-raises-with-multiple-statements

--- a/tests/unit/dispatch_rule/test_hwpc_dispatch_rule.py
+++ b/tests/unit/dispatch_rule/test_hwpc_dispatch_rule.py
@@ -132,15 +132,12 @@ def report_3(request):
 #########
 def validate_formula_id(formula_id_list, validation_list):
     """
-    assert if every element in formula_id_list are in validation list and
-    vice versa
-
-    validation_list must be sorted
+    assert if every element in formula_id_list are in validation list and vice versa
     """
-    assert len(formula_id_list) == len(validation_list)
     formula_id_list.sort()
+    validation_list.sort()
 
-    for a, b in zip(formula_id_list, validation_list):
+    for a, b in zip(formula_id_list, validation_list, strict=True):
         assert a == b
 
 

--- a/tests/unit/dispatch_rule/test_power_dispatch_rule.py
+++ b/tests/unit/dispatch_rule/test_power_dispatch_rule.py
@@ -43,15 +43,12 @@ def report1_socket0():
 
 def validate_formula_id(formula_id_list, validation_list):
     """
-    assert if every element in formula_id_list are in validation list and
-    vice versa
-
-    validation_list must be sorted
+    assert if every element in formula_id_list are in validation list and vice versa
     """
-    assert len(formula_id_list) == len(validation_list)
     formula_id_list.sort()
+    validation_list.sort()
 
-    for a, b in zip(formula_id_list, validation_list):
+    for a, b in zip(formula_id_list, validation_list, strict=True):
         assert a == b
 
 


### PR DESCRIPTION
[zip-without-explicit-strict](https://docs.astral.sh/ruff/rules/zip-without-explicit-strict/)