### PR TITLE
refactor: Timestamp parsing to handle timezone information

### DIFF
--- a/src/powerapi/report/report.py
+++ b/src/powerapi/report/report.py
@@ -126,7 +126,7 @@ class Report(Message):
         if isinstance(ts, str):
             try:
                 # ISO 8601 date format
-                return datetime.strptime(ts, "%Y-%m-%dT%H:%M:%S.%f")
+                return datetime.fromisoformat(ts)
             except ValueError:
                 # Unix timestamp format (in milliseconds)
                 return datetime.fromtimestamp(int(ts) / 1000)

--- a/tests/unit/report/test_hwpc_report.py
+++ b/tests/unit/report/test_hwpc_report.py
@@ -53,7 +53,7 @@ def test_create_hwpc_report_from_json_with_datetime_timestamp_format_create_a_HW
 
 def test_create_hwpc_report_from_json_with_str_timestamp_with_bad_format_raise_BadInputData():
     json_input = extract_rapl_reports_with_2_sockets(1)[0]
-    json_input['timestamp'] = '1970-09-01T090909.543'
+    json_input['timestamp'] = '1970-09-01T0909099.543'
     with pytest.raises(BadInputData):
         _ = HWPCReport.from_json(json_input)
 

--- a/tests/unit/report/test_power_report.py
+++ b/tests/unit/report/test_power_report.py
@@ -76,7 +76,7 @@ def test_create_power_report_from_json_with_datetime_timestamp_format_create_a_P
 
 def test_create_power_report_from_json_with_str_timestamp_with_bad_format_raise_BadInputData():
     json_input = gen_json_power_report(1)[0]
-    json_input['timestamp'] = '1970-09-01T090909.543'
+    json_input['timestamp'] = '1970-09-01T0909099.543'
     with pytest.raises(BadInputData):
         _ = PowerReport.from_json(json_input)
 
@@ -112,7 +112,7 @@ def test_create_power_report_from_csv_with_one_lines_create_an_power_report():
 def test_create_power_report_from_csv_with_bad_timestamp_format_raise_BadInputData():
     csv_lines = [("power",
                   {
-                      "timestamp": '1970-09-01T090909.543',
+                      "timestamp": '1970-09-01T0909099.543',
                       "sensor": "formula_group",
                       "target": "all",
                       "power": 42

--- a/tests/unit/report/test_procfs_report.py
+++ b/tests/unit/report/test_procfs_report.py
@@ -96,10 +96,30 @@ def test_create_procfs_report_from_csv_with_one_lines_create_an_procfs_report():
     assert isinstance(report, ProcfsReport)
 
 
-def test_create_procfs_report_from_csv_with_bad_timestamp_format_raise_BadInputData():
+def test_create_procfs_report_from_csv_with_good_timestamp_format():
     csv_lines = [("procfs",
                   {
                       "timestamp": "2021-09-14T123737.669237",
+                      "sensor": "formula_group",
+                      "target": ["firefox_cgroup", "emacs_cgroup",
+                                 "zsh_cgroup", "mongo_cgroup"],
+                      "usage": {
+                          "firefox_cgroup": 8.36,
+                          "emacs_cgroup": 5.52,
+                          "zsh_cgroup": 0.01,
+                          "mongo_cgroup": 0.64,
+                      },
+                      "global_cpu_usage": 27.600000000000012,
+                  }
+                  )
+                 ]
+    report = ProcfsReport.from_csv_lines(csv_lines)
+    assert isinstance(report, ProcfsReport)    
+
+def test_create_procfs_report_from_csv_with_good_timestamp_format_raise_BadInputData():
+    csv_lines = [("procfs",
+                  {
+                      "timestamp": "2021-09-14T1234737.669237",
                       "sensor": "formula_group",
                       "target": ["firefox_cgroup", "emacs_cgroup",
                                  "zsh_cgroup", "mongo_cgroup"],

--- a/tests/unit/report/test_procfs_report.py
+++ b/tests/unit/report/test_procfs_report.py
@@ -61,7 +61,7 @@ def test_create_procfs_report_from_json_with_str_timestamp_with_bad_format_raise
     procfs_timeline,
 ):
     json_input = gen_json_procfs_report(1, procfs_timeline[0])[0]
-    json_input["timestamp"] = "1970-09-01T090909.543"
+    json_input["timestamp"] = "1970-09-01T0909099.543"
     with pytest.raises(BadInputData):
         _ = ProcfsReport.from_json(json_input)
 
@@ -141,7 +141,7 @@ def test_create_procfs_report_from_csv_with_good_timestamp_format():
     assert isinstance(report, ProcfsReport)
 
 
-def test_create_procfs_report_from_csv_with_good_timestamp_format_raise_BadInputData():
+def test_create_procfs_report_from_csv_with_bad_timestamp_format_raise_BadInputDat():
     csv_lines = [
         (
             "procfs",

--- a/tests/unit/report/test_procfs_report.py
+++ b/tests/unit/report/test_procfs_report.py
@@ -27,47 +27,59 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import pytest
-
-from powerapi.report import ProcfsReport, BadInputData
 from datetime import datetime
 
+import pytest
+
+from powerapi.report import BadInputData, ProcfsReport
 from tests.utils.report.procfs import gen_json_procfs_report
 
 
 ########
 # JSON #
 ########
-def test_create_procfs_report_from_json_wit_str_timestamp_create_a_ProcfsReport(procfs_timeline):
+def test_create_procfs_report_from_json_wit_str_timestamp_create_a_ProcfsReport(
+    procfs_timeline,
+):
     json_input = gen_json_procfs_report(1, procfs_timeline[0])[0]
     report = ProcfsReport.from_json(json_input)
     assert isinstance(report, ProcfsReport)
 
 
-def test_create_procfs_report_from_json_with_datetime_timestamp_format_create_a_ProcfsReport(procfs_timeline):
+def test_create_procfs_report_from_json_with_datetime_timestamp_format_create_a_ProcfsReport(
+    procfs_timeline,
+):
     json_input = gen_json_procfs_report(1, procfs_timeline[0])[0]
-    json_input['timestamp'] = datetime.strptime(json_input['timestamp'], "%Y-%m-%dT%H:%M:%S.%f")
+    json_input["timestamp"] = datetime.strptime(
+        json_input["timestamp"], "%Y-%m-%dT%H:%M:%S.%f"
+    )
     report = ProcfsReport.from_json(json_input)
     assert isinstance(report, ProcfsReport)
 
 
-def test_create_procfs_report_from_json_with_str_timestamp_with_bad_format_raise_BadInputData(procfs_timeline):
+def test_create_procfs_report_from_json_with_str_timestamp_with_bad_format_raise_BadInputData(
+    procfs_timeline,
+):
     json_input = gen_json_procfs_report(1, procfs_timeline[0])[0]
-    json_input['timestamp'] = "1970-09-01T090909.543"
+    json_input["timestamp"] = "1970-09-01T090909.543"
     with pytest.raises(BadInputData):
         _ = ProcfsReport.from_json(json_input)
 
 
-def test_create_procfs_report_from_json_without_timestamp_field_raise_BadInputData(procfs_timeline):
+def test_create_procfs_report_from_json_without_timestamp_field_raise_BadInputData(
+    procfs_timeline,
+):
     json_input = gen_json_procfs_report(1, procfs_timeline[0])[0]
-    del json_input['timestamp']
+    del json_input["timestamp"]
     with pytest.raises(BadInputData):
         _ = ProcfsReport.from_json(json_input)
 
 
-def test_create_procfs_report_from_json_without_sensor_field_raise_BadInputData(procfs_timeline):
+def test_create_procfs_report_from_json_without_sensor_field_raise_BadInputData(
+    procfs_timeline,
+):
     json_input = gen_json_procfs_report(1, procfs_timeline[0])[0]
-    del json_input['sensor']
+    del json_input["sensor"]
     with pytest.raises(BadInputData):
         _ = ProcfsReport.from_json(json_input)
 
@@ -76,99 +88,129 @@ def test_create_procfs_report_from_json_without_sensor_field_raise_BadInputData(
 # CSV #
 #######
 def test_create_procfs_report_from_csv_with_one_lines_create_an_procfs_report():
-    csv_lines = [("procfs",
-                  {
-                      "timestamp": "2021-09-14T12:37:37.669237",
-                      "sensor": "formula_group",
-                      "target": ["firefox_cgroup", "emacs_cgroup",
-                                 "zsh_cgroup", "mongo_cgroup"],
-                      "usage": {
-                          "firefox_cgroup": 8.36,
-                          "emacs_cgroup": 5.52,
-                          "zsh_cgroup": 0.01,
-                          "mongo_cgroup": 0.64,
-                      },
-                      "global_cpu_usage": 27.600000000000012,
-                  }
-                  )
-                 ]
+    csv_lines = [
+        (
+            "procfs",
+            {
+                "timestamp": "2021-09-14T12:37:37.669237",
+                "sensor": "formula_group",
+                "target": [
+                    "firefox_cgroup",
+                    "emacs_cgroup",
+                    "zsh_cgroup",
+                    "mongo_cgroup",
+                ],
+                "usage": {
+                    "firefox_cgroup": 8.36,
+                    "emacs_cgroup": 5.52,
+                    "zsh_cgroup": 0.01,
+                    "mongo_cgroup": 0.64,
+                },
+                "global_cpu_usage": 27.600000000000012,
+            },
+        )
+    ]
     report = ProcfsReport.from_csv_lines(csv_lines)
     assert isinstance(report, ProcfsReport)
 
 
 def test_create_procfs_report_from_csv_with_good_timestamp_format():
-    csv_lines = [("procfs",
-                  {
-                      "timestamp": "2021-09-14T123737.669237",
-                      "sensor": "formula_group",
-                      "target": ["firefox_cgroup", "emacs_cgroup",
-                                 "zsh_cgroup", "mongo_cgroup"],
-                      "usage": {
-                          "firefox_cgroup": 8.36,
-                          "emacs_cgroup": 5.52,
-                          "zsh_cgroup": 0.01,
-                          "mongo_cgroup": 0.64,
-                      },
-                      "global_cpu_usage": 27.600000000000012,
-                  }
-                  )
-                 ]
+    csv_lines = [
+        (
+            "procfs",
+            {
+                "timestamp": "2021-09-14T123737.669237",
+                "sensor": "formula_group",
+                "target": [
+                    "firefox_cgroup",
+                    "emacs_cgroup",
+                    "zsh_cgroup",
+                    "mongo_cgroup",
+                ],
+                "usage": {
+                    "firefox_cgroup": 8.36,
+                    "emacs_cgroup": 5.52,
+                    "zsh_cgroup": 0.01,
+                    "mongo_cgroup": 0.64,
+                },
+                "global_cpu_usage": 27.600000000000012,
+            },
+        )
+    ]
     report = ProcfsReport.from_csv_lines(csv_lines)
-    assert isinstance(report, ProcfsReport)    
+    assert isinstance(report, ProcfsReport)
+
 
 def test_create_procfs_report_from_csv_with_good_timestamp_format_raise_BadInputData():
-    csv_lines = [("procfs",
-                  {
-                      "timestamp": "2021-09-14T1234737.669237",
-                      "sensor": "formula_group",
-                      "target": ["firefox_cgroup", "emacs_cgroup",
-                                 "zsh_cgroup", "mongo_cgroup"],
-                      "usage": {
-                          "firefox_cgroup": 8.36,
-                          "emacs_cgroup": 5.52,
-                          "zsh_cgroup": 0.01,
-                          "mongo_cgroup": 0.64,
-                      },
-                      "global_cpu_usage": 27.600000000000012,
-                  }
-                  )
-                 ]
+    csv_lines = [
+        (
+            "procfs",
+            {
+                "timestamp": "2021-09-14T1234737.669237",
+                "sensor": "formula_group",
+                "target": [
+                    "firefox_cgroup",
+                    "emacs_cgroup",
+                    "zsh_cgroup",
+                    "mongo_cgroup",
+                ],
+                "usage": {
+                    "firefox_cgroup": 8.36,
+                    "emacs_cgroup": 5.52,
+                    "zsh_cgroup": 0.01,
+                    "mongo_cgroup": 0.64,
+                },
+                "global_cpu_usage": 27.600000000000012,
+            },
+        )
+    ]
     with pytest.raises(BadInputData):
         _ = ProcfsReport.from_csv_lines(csv_lines)
 
 
 def test_create_procfs_report_from_csv_with_two_lines_raise_BadInputData():
-    csv_lines = [("procfs",
-                  {
-                      "timestamp": "2021-09-14T12:37:37.669237",
-                      "sensor": "formula_group",
-                      "target": ["firefox_cgroup", "emacs_cgroup",
-                                 "zsh_cgroup", "mongo_cgroup"],
-                      "usage": {
-                          "firefox_cgroup": 8.36,
-                          "emacs_cgroup": 5.52,
-                          "zsh_cgroup": 0.01,
-                          "mongo_cgroup": 0.64,
-                      },
-                      "global_cpu_usage": 27.600000000000012,
-                  }
-                  ),
-                 ("procfs",
-                  {
-                      "timestamp": "2021-09-14T12:37:38.669237",
-                      "sensor": "formula_group",
-                      "target": ["firefox_cgroup", "emacs_cgroup",
-                                 "zsh_cgroup", "mongo_cgroup"],
-                      "usage": {
-                          "firefox_cgroup": 8.36,
-                          "emacs_cgroup": 5.52,
-                          "zsh_cgroup": 0.01,
-                          "mongo_cgroup": 0.64,
-                      },
-                      "global_cpu_usage": 27.600000000000012,
-                  }
-                  )
-                 ]
+    csv_lines = [
+        (
+            "procfs",
+            {
+                "timestamp": "2021-09-14T12:37:37.669237",
+                "sensor": "formula_group",
+                "target": [
+                    "firefox_cgroup",
+                    "emacs_cgroup",
+                    "zsh_cgroup",
+                    "mongo_cgroup",
+                ],
+                "usage": {
+                    "firefox_cgroup": 8.36,
+                    "emacs_cgroup": 5.52,
+                    "zsh_cgroup": 0.01,
+                    "mongo_cgroup": 0.64,
+                },
+                "global_cpu_usage": 27.600000000000012,
+            },
+        ),
+        (
+            "procfs",
+            {
+                "timestamp": "2021-09-14T12:37:38.669237",
+                "sensor": "formula_group",
+                "target": [
+                    "firefox_cgroup",
+                    "emacs_cgroup",
+                    "zsh_cgroup",
+                    "mongo_cgroup",
+                ],
+                "usage": {
+                    "firefox_cgroup": 8.36,
+                    "emacs_cgroup": 5.52,
+                    "zsh_cgroup": 0.01,
+                    "mongo_cgroup": 0.64,
+                },
+                "global_cpu_usage": 27.600000000000012,
+            },
+        ),
+    ]
     with pytest.raises(BadInputData):
         _ = ProcfsReport.from_csv_lines(csv_lines)
 
@@ -177,19 +219,21 @@ def test_create_procfs_report_from_csv_with_two_lines_raise_BadInputData():
 # METADATA #
 ############
 
+
 def test_creating_report_with_metadata():
-    report = ProcfsReport(("2021-09-14T12:37:37.168817"),
-                          'toto',
-                          ["firefox_cgroup", "emacs_cgroup", "zsh_cgroup", "mongo_cgroup"],
-                          {
-                              "firefox_cgroup": 8.36,
-                              "emacs_cgroup": 5.52,
-                              "zsh_cgroup": 0.01,
-                              "mongo_cgroup": 0.64, },
-                          42,
-                          {
-                              "tag": 1}
-                          )
+    report = ProcfsReport(
+        ("2021-09-14T12:37:37.168817"),
+        "toto",
+        ["firefox_cgroup", "emacs_cgroup", "zsh_cgroup", "mongo_cgroup"],
+        {
+            "firefox_cgroup": 8.36,
+            "emacs_cgroup": 5.52,
+            "zsh_cgroup": 0.01,
+            "mongo_cgroup": 0.64,
+        },
+        42,
+        {"tag": 1},
+    )
     assert report.metadata["tag"] == 1
 
 
@@ -202,22 +246,28 @@ def test_create_report_from_json_with_metadata(procfs_timeline):
 
 
 def test_create_report_from_csv_with_metadata():
-    csv_lines = [("procfs",
-                  {
-                      "timestamp": "2021-09-14T12:37:38.669237",
-                      "sensor": "formula_group",
-                      "target": ["firefox_cgroup", "emacs_cgroup",
-                                 "zsh_cgroup", "mongo_cgroup"],
-                      "usage": {
-                          "firefox_cgroup": 8.36,
-                          "emacs_cgroup": 5.52,
-                          "zsh_cgroup": 0.01,
-                          "mongo_cgroup": 0.64,
-                      },
-                      "global_cpu_usage": 27.600000000000012,
-                      "tag": 1
-                  }
-                  )
-                 ]
+    csv_lines = [
+        (
+            "procfs",
+            {
+                "timestamp": "2021-09-14T12:37:38.669237",
+                "sensor": "formula_group",
+                "target": [
+                    "firefox_cgroup",
+                    "emacs_cgroup",
+                    "zsh_cgroup",
+                    "mongo_cgroup",
+                ],
+                "usage": {
+                    "firefox_cgroup": 8.36,
+                    "emacs_cgroup": 5.52,
+                    "zsh_cgroup": 0.01,
+                    "mongo_cgroup": 0.64,
+                },
+                "global_cpu_usage": 27.600000000000012,
+                "tag": 1,
+            },
+        )
+    ]
     report = ProcfsReport.from_csv_lines(csv_lines)
     assert report.metadata["tag"] == 1


### PR DESCRIPTION
## Description
This PR fixes the timestamp parsing in `Report._extract_timestamp()` to properly handle ISO 8601 timestamps that include timezone information.

## Solution
- Replaced `datetime.strptime()` with `datetime.fromisoformat()` which correctly handles timezone information

Fixes #586 