### PR TITLE
refactor: Fix `pytest` related ruff warnings

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -23,5 +23,4 @@ ignore = [
     "B010",   # set-attr-with-constant
     "PT001",  # pytest-fixture-incorrect-parentheses-style
     "PT012",  # pytest-raises-with-multiple-statements
-    "PT022",  # pytest-useless-yield-fixture
 ]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -21,6 +21,5 @@ ignore = [
     "RUF013", # implicit-optional
 
     "B010",   # set-attr-with-constant
-    "PT001",  # pytest-fixture-incorrect-parentheses-style
     "PT012",  # pytest-raises-with-multiple-statements
 ]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -22,7 +22,6 @@ ignore = [
 
     "B010",   # set-attr-with-constant
     "PT001",  # pytest-fixture-incorrect-parentheses-style
-    "PT011",  # pytest-raises-too-broad
     "PT012",  # pytest-raises-with-multiple-statements
     "PT015",  # pytest-assert-always-false
     "PT022",  # pytest-useless-yield-fixture

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -23,6 +23,5 @@ ignore = [
     "B010",   # set-attr-with-constant
     "PT001",  # pytest-fixture-incorrect-parentheses-style
     "PT012",  # pytest-raises-with-multiple-statements
-    "PT015",  # pytest-assert-always-false
     "PT022",  # pytest-useless-yield-fixture
 ]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -21,5 +21,4 @@ ignore = [
     "RUF013", # implicit-optional
 
     "B010",   # set-attr-with-constant
-    "PT012",  # pytest-raises-with-multiple-statements
 ]

--- a/tests/unit/actor/abstract_test_actor.py
+++ b/tests/unit/actor/abstract_test_actor.py
@@ -140,7 +140,7 @@ def pytest_generate_tests_abstract(metafunc):
             metafunc.parametrize('content', [[]])
 
 
-@pytest.fixture()
+@pytest.fixture
 def pusher(database):
     """
     fixture that create a PusherActor before launching the test and stop it after the test end

--- a/tests/unit/actor/test_socket_interface.py
+++ b/tests/unit/actor/test_socket_interface.py
@@ -50,7 +50,7 @@ def check_socket(socket, socket_type, bind_address):
     assert socket_address == bind_address
 
 
-@pytest.fixture()
+@pytest.fixture
 def socket_interface():
     """Return a socket interface not initialized
 
@@ -58,7 +58,7 @@ def socket_interface():
     return SocketInterface(ACTOR_NAME, 100)
 
 
-@pytest.fixture()
+@pytest.fixture
 def initialized_socket_interface(socket_interface):
     """Return an initialized socket interface
 
@@ -70,7 +70,7 @@ def initialized_socket_interface(socket_interface):
     socket_interface.close()
 
 
-@pytest.fixture()
+@pytest.fixture
 def connected_interface(initialized_socket_interface):
     """ Return an initialized socket interface with an open connection to the
     push socket
@@ -81,7 +81,7 @@ def connected_interface(initialized_socket_interface):
     initialized_socket_interface.close()
 
 
-@pytest.fixture()
+@pytest.fixture
 def controlled_interface(initialized_socket_interface):
     """ Return an initialized socket interface with an open connection to the
     control socket
@@ -92,7 +92,7 @@ def controlled_interface(initialized_socket_interface):
     initialized_socket_interface.close()
 
 
-@pytest.fixture()
+@pytest.fixture
 def fully_connected_interface(initialized_socket_interface):
     """ Return an initialized socket interface with an open connection to the
     control and the push socket

--- a/tests/unit/actor/test_supervisor.py
+++ b/tests/unit/actor/test_supervisor.py
@@ -99,7 +99,7 @@ def supervisor(request):
     """
     supervisor = Supervisor()
     supervisor.actor_list = request.param
-    yield supervisor
+    return supervisor
 
 
 ###############

--- a/tests/unit/cli/conftest.py
+++ b/tests/unit/cli/conftest.py
@@ -286,7 +286,7 @@ def k8s_pre_processors(k8s_pre_processor_config):
     return processors
 
 
-@pytest.fixture()
+@pytest.fixture
 def subgroup_parser():
     """
     A subgroup parser with one argument "-a"
@@ -505,7 +505,7 @@ def test_files_path():
     return test_files_module.__path__[0]
 
 
-@pytest.fixture()
+@pytest.fixture
 def cli_configuration(config_file: str):
     """
     Load in sys.argv a configuration with arguments extracted from a json file
@@ -517,7 +517,7 @@ def cli_configuration(config_file: str):
     sys.argv = []
 
 
-@pytest.fixture()
+@pytest.fixture
 def empty_cli_configuration():
     """
     Clean the CLI arguments

--- a/tests/unit/cli/test_binding_manager.py
+++ b/tests/unit/cli/test_binding_manager.py
@@ -34,8 +34,7 @@ import pytest
 
 from powerapi.cli.binding_manager import PreProcessorBindingManager
 from powerapi.dispatcher import DispatcherActor
-from powerapi.exception import UnsupportedActorTypeException, UnexistingActorException, \
-    TargetActorAlreadyUsed
+from powerapi.exception import UnsupportedActorTypeException, UnexistingActorException, TargetActorAlreadyUsed
 from powerapi.processor.processor_actor import ProcessorActor
 
 
@@ -134,26 +133,28 @@ def test_check_processors_targets_are_unique_pass_without_reused_puller_in_bindi
         pytest.fail("Processors targets are not unique")
 
 
-def test_check_processor_targets_raise_exception_with_no_existing_puller(
-        pre_processor_binding_manager_with_unexisting_puller):
+def check_all_processors_targets(preprocessor_binding_manager: PreProcessorBindingManager):
+    """
+    Helper function that checks the processors targets of the given binding manager.
+    """
+    for processor in preprocessor_binding_manager.processors.values():
+        preprocessor_binding_manager.check_processor_targets(processor)
+
+
+def test_check_processor_targets_raise_exception_with_no_existing_puller(pre_processor_binding_manager_with_unexisting_puller):
     """
     Test that an exception is raised with a puller that doesn't exist
     """
-    pre_processor_binding_manager = pre_processor_binding_manager_with_unexisting_puller
     with pytest.raises(UnexistingActorException):
-        for _, processor in pre_processor_binding_manager.processors.items():
-            pre_processor_binding_manager.check_processor_targets(processor=processor)
+        check_all_processors_targets(pre_processor_binding_manager_with_unexisting_puller)
 
 
-def test_check_processor_targets_raise_exception_with_raise_exception_with_wrong_binding_types(
-        pre_processor_binding_manager_with_wrong_binding_types):
+def test_check_processor_targets_raise_exception_with_raise_exception_with_wrong_binding_types(pre_processor_binding_manager_with_wrong_binding_types):
     """
     Test that an exception is raised with a puller that doesn't exist
     """
-    pre_processor_binding_manager = pre_processor_binding_manager_with_wrong_binding_types
     with pytest.raises(UnsupportedActorTypeException):
-        for _, processor in pre_processor_binding_manager.processors.items():
-            pre_processor_binding_manager.check_processor_targets(processor=processor)
+        check_all_processors_targets(pre_processor_binding_manager_with_wrong_binding_types)
 
 
 def test_check_processor_targets_pass_with_correct_targets(pre_processor_binding_manager):
@@ -161,8 +162,7 @@ def test_check_processor_targets_pass_with_correct_targets(pre_processor_binding
     Test that validation of a configuration with existing targets of the correct type
     """
     try:
-        for _, processor in pre_processor_binding_manager.processors.items():
-            pre_processor_binding_manager.check_processor_targets(processor=processor)
+        check_all_processors_targets(pre_processor_binding_manager)
     except UnsupportedActorTypeException as e:
         pytest.fail(f'Unsupported actor type: {e}')
     except UnexistingActorException as e:

--- a/tests/unit/processor/pre/k8s/conftest.py
+++ b/tests/unit/processor/pre/k8s/conftest.py
@@ -52,4 +52,4 @@ def initialized_monitor_agent(initialized_metadata_cache_manager):
     Returns an initialized monitor agent.
     """
     agent = K8sMonitorAgent(initialized_metadata_cache_manager, 'manual', '', '')
-    yield agent
+    return agent

--- a/tests/unit/processor/pre/k8s/test_actor.py
+++ b/tests/unit/processor/pre/k8s/test_actor.py
@@ -63,7 +63,7 @@ class TestK8sProcessor(AbstractTestActor):
         actor.state.metadata_cache_manager = fx_initialized_metadata_cache_manager
         actor.state.manager = Mock()
         actor.state.monitor_agent = Mock()
-        yield actor
+        return actor
 
     @staticmethod
     @pytest.mark.usefixtures("shutdown_system")

--- a/tests/utils/db/influx2.py
+++ b/tests/utils/db/influx2.py
@@ -63,7 +63,7 @@ INFLUX2_DEFAULT_START_DATE = '1970-01-01T00:00:00Z'
 INFLUX2_MEASUREMENT_NAME = 'power_consumption'
 
 
-@pytest.fixture()
+@pytest.fixture
 def influx2_database():
     """
         connect to a local influx database (localhost:8086) and store data contained in the list influxdb_content


### PR DESCRIPTION
This PR fixes the following pytest related ruff warnings :
- `pytest-raises-too-broad`
- `pytest-assert-always-false`
- `pytest-ueless-yield-fixture`
- `pytest-fixture-incorrect-parentheses-style`
- `pytest-raises-with-multiple-statements`