### PR TITLE
build(pyproject): Pin packages version of the `lint` dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ docs = [
 ]
 
 lint = [
-    "ruff >= 0.9.6"
+    "ruff == 0.13.0"
 ]
 
 dev = [


### PR DESCRIPTION
This PR pins the version of the packages of the `lint` group in the `pyproject.toml` file in order to prevent running different versions locally and in the CI.