### PR TITLE
feat(database/json): Add support for file compression

### DIFF
--- a/src/powerapi/cli/common_cli_parsing_manager.py
+++ b/src/powerapi/cli/common_cli_parsing_manager.py
@@ -159,6 +159,7 @@ class CommonCLIParsingManager(RootConfigParsingManager):
         subparser_json_input.add_argument("n", "name", help_text="Name of the puller", default_value="puller_json")
         subparser_json_input.add_argument("m", "model", help_text="Expected report type")
         subparser_json_input.add_argument("f", "filepath", help_text="Input file path")
+        subparser_json_input.add_argument("c", "compression", default_value='auto', help_text="Compression type")
         self.add_subgroup_parser("input", subparser_json_input)
 
         subparser_mongo_output = SubgroupConfigParsingManager("mongodb")
@@ -252,6 +253,7 @@ class CommonCLIParsingManager(RootConfigParsingManager):
         subparser_json_output.add_argument("n", "name", help_text="Name of the pusher", default_value="pusher_json")
         subparser_json_output.add_argument("m", "model", help_text="Report type to be exported")
         subparser_json_output.add_argument("f", "filepath", help_text="Output file path")
+        subparser_json_output.add_argument("c", "compression", default_value="auto", help_text="Compression type")
         self.add_subgroup_parser("output", subparser_json_output)
 
         subparser_opentsdb_output = SubgroupConfigParsingManager("opentsdb")

--- a/src/powerapi/cli/generator.py
+++ b/src/powerapi/cli/generator.py
@@ -90,14 +90,16 @@ class Generator:
         Generate an actor class and actor start message from config dict
         """
         if self.component_group_name not in main_config:
-            raise PowerAPIException('Configuration error : no ' + self.component_group_name + ' specified')
+            raise PowerAPIException(f'Configuration error : Component {self.component_group_name} group is unknown')
 
         actors = {}
         for component_name, component_config in main_config[self.component_group_name].items():
             try:
                 actors[component_name] = self._gen_actor(component_config, main_config, component_name)
             except KeyError as exn:
-                raise PowerAPIException('Configuration error: Missing "%s" argument for %s component', exn.args[0], component_name) from exn
+                raise PowerAPIException(f'Configuration error: Missing "{exn.args[0]}" argument for {component_name} component') from exn
+            except ValueError as exn:
+                raise PowerAPIException(f'Configuration error: Invalid parameter for {component_name} component: {exn.args[0]}') from exn
 
         return actors
 
@@ -227,7 +229,7 @@ class PullerGenerator(DBActorGenerator):
         JSON Input database factory method.
         """
         from powerapi.database.json import JsonInput
-        return JsonInput(conf['model'], conf['filepath'])
+        return JsonInput(conf['model'], conf['filepath'], conf['compression'])
 
     @staticmethod
     def _socket_database_factory(conf: dict) -> ReadableDatabase:
@@ -291,7 +293,7 @@ class PusherGenerator(DBActorGenerator):
         JSON Output database factory method.
         """
         from powerapi.database.json import JsonOutput
-        return JsonOutput(conf['model'], conf['filepath'])
+        return JsonOutput(conf['model'], conf['filepath'], conf['compression'])
 
     @staticmethod
     def _mongodb_database_factory(conf: dict) -> WritableDatabase:

--- a/src/powerapi/database/json/driver.py
+++ b/src/powerapi/database/json/driver.py
@@ -28,13 +28,14 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from collections.abc import Iterable, Iterator
-from io import TextIOWrapper
 from os import fsync
 from pathlib import Path
+from typing import TextIO
 
 from powerapi.database.driver import ReadableDatabase, WritableDatabase
 from powerapi.database.exceptions import ConnectionFailed, WriteFailed, ReadFailed
 from powerapi.database.json.codecs import ReportDecoders, ReportEncoders
+from powerapi.database.json.file_handlers import FileHandlerRegistry
 from powerapi.report import Report
 
 
@@ -45,19 +46,26 @@ class JsonInput(ReadableDatabase):
     The input **should** follow the JSON Lines text format. (https://jsonlines.org/)
     """
 
-    def __init__(self, report_type: type[Report], input_filepath: str):
+    def __init__(self, report_type: type[Report], input_filepath: str, compression: str):
         """
         :param report_type: Type of the report handled by this database
         :param input_filepath: Path to the input file
+        :param compression: Compression method to use for the file
         """
         self.input_filepath = Path(input_filepath)
+        self.compression = compression
 
         self._report_decoder = ReportDecoders.get(report_type)
-        self._file: TextIOWrapper | None = None
+        self._file_handler = FileHandlerRegistry.get(compression, self.input_filepath)
+        self._file: TextIO | None = None
 
     def connect(self) -> None:
+        """
+        Connect the JSON input database driver.
+        :raise: ConnectionFailed if the operation fails
+        """
         try:
-            self._file = open(self.input_filepath, encoding='utf-8')
+            self._file = self._file_handler.open(self.input_filepath, 'r')
         except OSError as exn:
             raise ConnectionFailed(f'Failed to open input file: {exn}') from exn
 
@@ -110,31 +118,31 @@ class JsonOutput(WritableDatabase):
     The output follows the JSON Lines text format. (https://jsonlines.org/)
     """
 
-    def __init__(self, report_type: type[Report], output_filepath: str):
+    def __init__(self, report_type: type[Report], output_filepath: str, compression: str):
         """
         :param report_type: Type of the report handled by this database
         :param output_filepath: Path to the output file
         """
-        super().__init__()
-
         self.output_filepath = Path(output_filepath)
+        self.compression = compression
 
         self._report_encoder = ReportEncoders.get(report_type)
-        self._file: TextIOWrapper | None = None
+        self._file_handler = FileHandlerRegistry.get(compression, self.output_filepath)
+        self._file: TextIO | None = None
 
     def connect(self) -> None:
         """
-        Connect the JSON input database driver.
+        Connect the JSON output database driver.
         :raise: ConnectionFailed if the operation fails
         """
         try:
-            self._file = open(self.output_filepath, 'w', encoding='utf-8')
+            self._file = self._file_handler.open(self.output_filepath, 'w')
         except OSError as exn:
             raise ConnectionFailed(f'Failed to open output file: {exn}') from exn
 
     def disconnect(self) -> None:
         """
-        Disconnect the JSON input database driver.
+        Disconnect the JSON output database driver.
         """
         try:
             self._file.flush()

--- a/src/powerapi/database/json/file_handlers.py
+++ b/src/powerapi/database/json/file_handlers.py
@@ -1,0 +1,165 @@
+# Copyright (c) 2026, Inria
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from abc import ABC, abstractmethod
+from io import TextIOWrapper
+from pathlib import Path
+from typing import Literal, TextIO, ClassVar
+
+
+_OPEN_MODES = Literal['r', 'w']
+
+class FileHandler(ABC):
+    """
+    Base class for JSON file opening strategies.
+    """
+    compression_method: str = ''
+    supported_suffixes: tuple[str, ...] = ()
+
+    @classmethod
+    @abstractmethod
+    def open(cls, filepath: Path, mode: _OPEN_MODES) -> TextIO:
+        """
+        Open a file as a UTF-8 text stream using the handler strategy.
+        :param filepath: Path to the file to open
+        :param mode: Text mode used to open the file
+        :return: Open text stream
+        """
+        ...
+
+
+class RawFileHandler(FileHandler):
+    """
+    File handler for uncompressed JSON files.
+    """
+    compression_method = 'none'
+    supported_suffixes = ('.jsonl', '.jsonlines', '.ndjson', '.json', '')
+
+    @classmethod
+    def open(cls, filepath: Path, mode: _OPEN_MODES) -> TextIO:
+        return open(filepath, mode, encoding='utf-8')
+
+
+class GzipFileHandler(FileHandler):
+    """
+    File handler for gzip-compressed JSON files.
+    """
+    compression_method = 'gzip'
+    supported_suffixes = ('.gz', '.gzip')
+
+    @classmethod
+    def open(cls, filepath: Path, mode: _OPEN_MODES) -> TextIO:
+        from gzip import GzipFile
+        gzip_file = GzipFile(filepath, mode)
+        text_handler = TextIOWrapper(gzip_file, encoding='utf-8')
+        return text_handler
+
+
+class LzmaFileHandler(FileHandler):
+    """"
+    File handler for lzma-compressed JSON files.
+    """
+    compression_method = 'lzma'
+    supported_suffixes = ('.xz', '.lzma')
+
+    @classmethod
+    def open(cls, filepath: Path, mode: _OPEN_MODES) -> TextIO:
+        from lzma import LZMAFile
+        lzma_file = LZMAFile(filepath, mode)
+        text_handler = TextIOWrapper(lzma_file, encoding='utf-8')
+        return text_handler
+
+
+class FileHandlerRegistry:
+    """
+    Registry of JSON file handlers.
+    """
+    _file_handlers: ClassVar[list[type[FileHandler]]] = []
+
+    @classmethod
+    def register(cls, handler: type[FileHandler]) -> None:
+        """
+        Register a file handler in lookup order.
+        :param handler: Handler class to register
+        """
+        cls._file_handlers.append(handler)
+
+    @classmethod
+    def _get_from_compression_method(cls, compression_method: str) -> type[FileHandler]:
+        """
+        Retrieve a handler from its compression method name.
+        :param compression_method: Name of the compression method to resolve
+        :return: File handler matching the requested compression method
+        :raises ValueError: If the compression method is not recognized
+        """
+        for handler in cls._file_handlers:
+            if handler.compression_method == compression_method:
+                return handler
+
+        raise ValueError(f'Unknown compression method: {compression_method}')
+
+    @classmethod
+    def _get_from_file_extension(cls, filepath: Path) -> type[FileHandler]:
+        """
+        Infer a handler from the suffix of the given filepath.
+        :param filepath: Path to the file
+        :return: Handler matching the filepath suffix
+        :raises ValueError: If the file extension is not recognized
+        """
+        suffix = filepath.suffix.casefold()
+        for handler in cls._file_handlers:
+            if suffix in handler.supported_suffixes:
+                return handler
+
+        raise ValueError(f'Unknown file extension for: {filepath}')
+
+    @classmethod
+    def get(cls, compression_method: str, filepath: Path) -> type[FileHandler]:
+        """
+        Resolve the file handler for a JSON file.
+
+        When the ``compression_method`` parameter is ``auto``, the handler is inferred from the filepath suffix.
+        Otherwise, the compression method is resolved explicitly.
+
+        :param compression_method: Compression method name or ``auto``
+        :param filepath: Path to the file associated with the handler lookup
+        :return: Matching file handler
+        :raises ValueError: If no handler matches the requested method or file suffix
+        """
+        method = compression_method.casefold()
+        if method == 'auto':
+            handler = cls._get_from_file_extension(filepath)
+        else:
+            handler = cls._get_from_compression_method(method)
+
+        return handler
+
+
+FileHandlerRegistry.register(RawFileHandler)
+FileHandlerRegistry.register(GzipFileHandler)
+FileHandlerRegistry.register(LzmaFileHandler)

--- a/tests/unit/database/json/__init__.py
+++ b/tests/unit/database/json/__init__.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2026, Inria
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/tests/unit/database/json/test_file_handlers.py
+++ b/tests/unit/database/json/test_file_handlers.py
@@ -1,0 +1,111 @@
+# Copyright (c) 2026, Inria
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from pathlib import Path
+
+import pytest
+
+from powerapi.database.json.file_handlers import FileHandlerRegistry, RawFileHandler, GzipFileHandler, LzmaFileHandler
+
+
+def make_filepath(suffix: str = '.jsonl', stem: str = "pytest-powerapi", root: str = "/tmp") -> Path:
+    """
+    Helper method to create a file path.
+    :param suffix: File suffix
+    :param stem: File stem
+    :param root: File root directory
+    :return: File path
+    """
+    return Path(root) / f"{stem}{suffix}"
+
+
+@pytest.mark.parametrize('compression_method', ['none', 'gzip', 'lzma'])
+def test_registry_get_compression_method(compression_method):
+    """
+    Registry should return the handler matching an explicit compression method.
+    """
+    filepath = make_filepath()
+    handler = FileHandlerRegistry.get(compression_method, filepath)
+
+    assert handler.compression_method == compression_method
+
+
+def test_registry_get_invalid_compression_method() -> None:
+    """
+    Registry should raise a ValueError for an unsupported compression method.
+    """
+    filepath = make_filepath()
+
+    with pytest.raises(ValueError, match='Unknown compression method'):
+        FileHandlerRegistry.get('invalid', filepath)
+
+
+@pytest.mark.parametrize('file_extension', ['.jsonl', '.jsonlines', '.ndjson', '.json', ''])
+def test_registry_get_none_compression_method_from_file_extension(file_extension):
+    """
+    Auto-detection should resolve uncompressed JSON file suffixes to the raw file handler.
+    """
+    filepath = make_filepath(file_extension)
+    handler = FileHandlerRegistry.get('auto', filepath)
+
+    assert handler is RawFileHandler
+    assert handler.compression_method == 'none'
+
+
+@pytest.mark.parametrize('file_extension', ['.gz', '.gzip'])
+def test_registry_get_gzip_compression_method_from_file_extension(file_extension):
+    """
+    Auto-detection should resolve gzip-related suffixes to the Gzip file handler.
+    """
+    filepath = make_filepath(file_extension)
+    handler = FileHandlerRegistry.get('auto', filepath)
+
+    assert handler is GzipFileHandler
+    assert handler.compression_method == 'gzip'
+
+
+@pytest.mark.parametrize('file_extension', ['.xz', '.lzma'])
+def test_registry_get_lzma_compression_method_from_file_extension(file_extension):
+    """
+    Auto-detection should resolve lzma-related suffixes to the LZMA file handler.
+    """
+    filepath = make_filepath(file_extension)
+    handler = FileHandlerRegistry.get('auto', filepath)
+
+    assert handler is LzmaFileHandler
+    assert handler.compression_method == 'lzma'
+
+
+def test_registry_get_unknown_compression_method_from_file_extension():
+    """
+    Auto-detection should raise a ValueError for an unknown file suffix.
+    """
+    filepath = make_filepath('.invalid')
+
+    with pytest.raises(ValueError, match='Unknown file extension'):
+        FileHandlerRegistry.get('auto', filepath)

--- a/tests/utils/cli/several_inputs_outputs_stream_mode_enabled_configuration.json
+++ b/tests/utils/cli/several_inputs_outputs_stream_mode_enabled_configuration.json
@@ -18,7 +18,8 @@
       "puller4": {
           "model": "HWPCReport",
           "type": "json",
-          "filepath": "/tmp/pytest-powerapi.jsonl"
+          "filepath": "/tmp/pytest-powerapi.jsonl",
+          "compression": "none"
       }
   },
   "output": {
@@ -30,7 +31,8 @@
       "seventh_pusher": {
           "type": "json",
           "model": "FormulaReport",
-          "filepath": "my_output_filepath"
+          "filepath": "my_output_filepath",
+          "compression": "none"
       }
   }
 }

--- a/tests/utils/cli/single_input_multiple_outputs_with_different_report_type_configuration.json
+++ b/tests/utils/cli/single_input_multiple_outputs_with_different_report_type_configuration.json
@@ -13,7 +13,8 @@
     "powerrep1": {
       "type": "json",
       "model": "PowerReport",
-      "filepath": "/tmp/pytest-powerrep.jsonl"
+      "filepath": "/tmp/pytest-powerrep.jsonl",
+      "compression": "none"
     },
     "powerrep2": {
       "type": "csv",
@@ -23,7 +24,8 @@
     "formularep": {
       "type": "json",
       "model": "FormulaReport",
-      "filepath": "/tmp/pytest-formularep.jsonl"
+      "filepath": "/tmp/pytest-formularep.jsonl",
+      "compression": "none"
     }
   }
 }


### PR DESCRIPTION
This PR adds the support for transparent (de-)compression for input/output files using the `json` database driver.
The supported compression methods are :
- `none` for uncompressed files
- `auto` where the compression method is inferred from the file extension (default)
- `gzip` for Gzip compression
- `lzma` for LZMA compression