### PR TITLE
fix(processor): Make monitor agent polling cancellable

### DIFF
--- a/src/powerapi/processor/pre/k8s/monitor_agent.py
+++ b/src/powerapi/processor/pre/k8s/monitor_agent.py
@@ -32,7 +32,6 @@ import sys
 from dataclasses import dataclass
 from multiprocessing import Process, Event
 from signal import signal, SIGTERM, SIGINT
-from time import sleep
 
 from kubernetes import client, config, watch
 from kubernetes.client import V1Pod, V1PodList, V1ContainerStatus
@@ -158,7 +157,9 @@ class K8sMonitorAgent(Process):
         while not self._stop_monitoring.is_set():
             resource_id = self.fetch_list_all_pod_for_all_namespaces(api_client)
             self.watch_list_pod_for_all_namespaces(api_client, resource_id)
-            sleep(K8S_MONITOR_RETRY_DELAY_SECONDS)
+
+            if self._stop_monitoring.wait(K8S_MONITOR_RETRY_DELAY_SECONDS):
+                break
 
     @staticmethod
     def get_containers_id_name_from_statuses(container_statuses: list[V1ContainerStatus]) -> dict[str, str]:

--- a/src/powerapi/processor/pre/openstack/monitor_agent.py
+++ b/src/powerapi/processor/pre/openstack/monitor_agent.py
@@ -31,7 +31,6 @@ import sys
 from dataclasses import dataclass
 from multiprocessing import Process, Event
 from signal import signal, SIGINT, SIGTERM
-from time import sleep
 
 from openstack.compute.v2.server import Server
 from openstack.connection import Connection
@@ -88,7 +87,7 @@ class OpenStackMonitorAgent(Process):
         Setup signal handlers for the current Process.
         """
         def stop_monitor(_, __):
-            self._stop_monitoring = True
+            self._stop_monitoring.set()
             sys.exit(0)
 
         signal(SIGTERM, stop_monitor)
@@ -104,11 +103,12 @@ class OpenStackMonitorAgent(Process):
         # Prevents orphaned entries that no longer exist in the OpenStack API.
         self.metadata_cache_manager.clear_metadata_cache()
 
-        while not self._stop_monitoring:
+        while not self._stop_monitoring.is_set():
             for server in self.fetch_servers_metadata(openstack_api):
                 self.metadata_cache_manager.update_server_metadata(server)
 
-            sleep(self.config.polling_interval)
+            if self._stop_monitoring.wait(self.config.polling_interval):
+                break
 
     @staticmethod
     def build_metadata_cache_entry_from_server(server: Server) -> ServerMetadata:


### PR DESCRIPTION
This PR improves shutdown handling for the Kubernetes and OpenStack monitoring agents.
It replaces blocking sleep calls with interruptible event waits, allowing the agents to react promptly to shutdown signals during polling delays.