### PR TITLE
refactor(report)!: Restrict metadata to string entries

### DIFF
--- a/src/powerapi/database/clickhouse/codecs.py
+++ b/src/powerapi/database/clickhouse/codecs.py
@@ -42,7 +42,7 @@ class PowerReportEncoder(ReportEncoder[PowerReport, tuple]):
             report.sensor,
             report.target,
             report.power,
-            report.flatten_tags(report.metadata),
+            report.metadata,
         )
 
 

--- a/src/powerapi/database/influxdb2/codecs.py
+++ b/src/powerapi/database/influxdb2/codecs.py
@@ -40,7 +40,7 @@ class PowerReportEncoder(ReportEncoder[PowerReport, dict]):
     def encode(report: PowerReport, opts: CodecOptions | None = None) -> dict:
         return {
             'measurement': 'powerrep',
-            'tags': {'sensor': report.sensor, 'target': report.target} | report.flatten_tags(report.metadata),
+            'tags': {'sensor': report.sensor, 'target': report.target} | report.metadata,
             'fields': {'power_estimation': report.power},
             'time': report.timestamp,
         }

--- a/src/powerapi/database/prometheus/codecs.py
+++ b/src/powerapi/database/prometheus/codecs.py
@@ -58,8 +58,7 @@ class PowerReportEncoder(ReportEncoder[PowerReport, PowerReportMetrics]):
 
     @staticmethod
     def encode(report: PowerReport, opts: EncoderOptions | None = None) -> PowerReportMetrics:
-        flattened_tags = report.flatten_tags(report.metadata)
-        dynamic_tags = [flattened_tags.get(tag_name, 'unknown') for tag_name in opts.dynamic_tags_name]
+        dynamic_tags = [report.metadata.get(tag_name, 'unknown') for tag_name in opts.dynamic_tags_name]
         labels = (report.sensor, report.target, *dynamic_tags)
         return PowerReportMetrics(labels, report.timestamp.timestamp(), report.power)
 

--- a/src/powerapi/report/control_report.py
+++ b/src/powerapi/report/control_report.py
@@ -28,7 +28,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from datetime import datetime
-from typing import Any
 
 from powerapi.report import Report
 
@@ -39,7 +38,7 @@ class ControlReport(Report):
     Stores information about an action, which can be used to control external tools from a formula.
     """
 
-    def __init__(self, timestamp: datetime, sensor: str, target: str, action: str, parameters: list, metadata: dict[str, Any] | None = None):
+    def __init__(self, timestamp: datetime, sensor: str, target: str, action: str, parameters: list, metadata: dict[str, str] | None = None):
         """
         :param timestamp: Report timestamp
         :param sensor: Sensor name

--- a/src/powerapi/report/formula_report.py
+++ b/src/powerapi/report/formula_report.py
@@ -28,7 +28,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from datetime import datetime
-from typing import Any
 
 from powerapi.report.report import Report
 
@@ -39,7 +38,7 @@ class FormulaReport(Report):
     Used to export information about a running formula.
     """
 
-    def __init__(self, timestamp: datetime, sensor: str, target: str, metadata: dict[str, Any] | None = None):
+    def __init__(self, timestamp: datetime, sensor: str, target: str, metadata: dict[str, str] | None = None):
         """
         :param timestamp: Report timestamp
         :param sensor: Sensor name

--- a/src/powerapi/report/hwpc_report.py
+++ b/src/powerapi/report/hwpc_report.py
@@ -28,7 +28,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from datetime import datetime
-from typing import Any
 
 from powerapi.report.report import Report
 
@@ -39,7 +38,7 @@ class HWPCReport(Report):
     Stores Hardware Performance Counters samples coming from the HwPC-Sensor.
     """
 
-    def __init__(self, timestamp: datetime, sensor: str, target: str, groups: dict[str, dict], metadata: dict[str, Any] | None = None):
+    def __init__(self, timestamp: datetime, sensor: str, target: str, groups: dict[str, dict], metadata: dict[str, str] | None = None):
         """
         :param timestamp: Timestamp of the report
         :param sensor: Sensor name

--- a/src/powerapi/report/power_report.py
+++ b/src/powerapi/report/power_report.py
@@ -28,7 +28,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from datetime import datetime
-from typing import Any
 
 from powerapi.report.report import Report
 
@@ -39,7 +38,7 @@ class PowerReport(Report):
     Used to export the power estimations computed by a formula.
     """
 
-    def __init__(self, timestamp: datetime, sensor: str, target: str, power: float, metadata: dict[str, Any] | None = None):
+    def __init__(self, timestamp: datetime, sensor: str, target: str, power: float, metadata: dict[str, str] | None = None):
         """
         :param timestamp: Report timestamp
         :param sensor: Sensor name

--- a/src/powerapi/report/report.py
+++ b/src/powerapi/report/report.py
@@ -30,7 +30,6 @@
 from collections import Counter
 from collections.abc import Iterable
 from datetime import datetime
-from typing import Any
 from zlib import crc32
 
 from powerapi.actor.message import Message
@@ -43,7 +42,7 @@ class Report(Message):
     Report abstract class.
     """
 
-    def __init__(self, timestamp: datetime, sensor: str, target: str, metadata: dict[str, Any] | None = None):
+    def __init__(self, timestamp: datetime, sensor: str, target: str, metadata: dict[str, str] | None = None):
         """
         :param timestamp: Timestamp of the measurements
         :param sensor: Name of the sensor from which the measurements were taken from
@@ -80,23 +79,4 @@ class Report(Message):
         return {
             tag_orig: (tag_new if conflict_count[tag_new] == 1 else f'{tag_new}_{crc32(tag_orig.encode()):x}')
             for tag_orig, tag_new in sanitized_tags.items()
-        }
-
-    @staticmethod
-    def flatten_tags(tags: dict[str, Any], separator: str = '_') -> dict[str, Any]:
-        """
-        Flatten nested dictionaries within a tags dictionary.
-
-        This method takes a dictionary of tags, which may contain nested dictionaries as values, and flattens them into
-        a single-level dictionary. Each key in the flattened dictionary is constructed by concatenating the keys from
-        the nested dictionaries with their parent keys, separated by the specified separator.
-
-        This is particularly useful for databases that only support canonical (non-nested) types as values.
-        :param tags: Input tags dict
-        :param separator: Separator to use for the flattened tags name
-        :return: Flattened tags dict
-        """
-        return {
-            f"{pkey}{separator}{ckey}" if isinstance(pvalue, dict) else pkey: cvalue for pkey, pvalue in tags.items()
-            for ckey, cvalue in (pvalue.items() if isinstance(pvalue, dict) else {pkey: pvalue}.items())
         }

--- a/tests/unit/database/clickhouse/test_codecs.py
+++ b/tests/unit/database/clickhouse/test_codecs.py
@@ -41,12 +41,11 @@ def test_get_power_report_encoder() -> None:
 
 def test_encode_power_report() -> None:
     """
-    Encoder should convert a PowerReport into a ClickHouse row and flatten its metadata.
+    Encoder should convert a PowerReport into a ClickHouse row with its metadata.
     """
-    metadata = {'scope': 'test', 'k8s': {'namespace': 'pytest'}}
+    metadata = {'scope': 'test', 'k8s_namespace': 'pytest'}
     report = PowerReport(datetime.now(tz=UTC), 'sensor', 'pytest', 42.5, metadata)
 
     encoded_report = PowerReportEncoder.encode(report)
 
-    expected_metadata = {'scope': 'test', 'k8s_namespace': 'pytest'}
-    assert encoded_report == (report.timestamp, 'sensor', 'pytest', 42.5, expected_metadata)
+    assert encoded_report == (report.timestamp, 'sensor', 'pytest', 42.5, metadata)

--- a/tests/unit/dispatch_rule/test_power_dispatch_rule.py
+++ b/tests/unit/dispatch_rule/test_power_dispatch_rule.py
@@ -38,7 +38,7 @@ TARGET1 = 'target1'
 
 @pytest.fixture
 def report1_socket0():
-    return PowerReport(TS1, SENSOR1, TARGET1, 1234, {'socket': 0, 'core': 0})
+    return PowerReport(TS1, SENSOR1, TARGET1, 1234, {'socket': '0', 'core': '0'})
 
 
 def validate_formula_id(formula_id_list, validation_list):
@@ -73,7 +73,7 @@ def test_get_formula_id_with_socket_rule_must_return_good_id(report1_socket0):
     get formula id from reports with a rule that dispatch by target :
     """
     ids = PowerDispatchRule(PowerDepthLevel.SOCKET).get_formula_id(report1_socket0)
-    validate_formula_id(ids, [(SENSOR1, 0)])
+    validate_formula_id(ids, [(SENSOR1, '0')])
 
 
 def test_get_formula_id_with_core_rule_must_return_good_id(report1_socket0):
@@ -81,4 +81,4 @@ def test_get_formula_id_with_core_rule_must_return_good_id(report1_socket0):
     get formula id from reports with a rule that dispatch by target :
     """
     ids = PowerDispatchRule(PowerDepthLevel.CORE).get_formula_id(report1_socket0)
-    validate_formula_id(ids, [(SENSOR1, 0, 0)])
+    validate_formula_id(ids, [(SENSOR1, '0', '0')])

--- a/tests/unit/report/conftest.py
+++ b/tests/unit/report/conftest.py
@@ -54,7 +54,7 @@ def power_report_with_metadata(power_report_without_metadata) -> PowerReport:
     """
     power_report_without_metadata.metadata = {
         'scope': 'cpu',
-        'socket': 0,
+        'socket': '0',
         'formula': '0000000000000000000000000000000000000000'
     }
     return power_report_without_metadata
@@ -66,29 +66,3 @@ def power_report_with_metadata_expected_tags(power_report_with_metadata) -> set[
     Returns the expected tags for the power report with single-level metadata.
     """
     return {'sensor', 'target', 'scope', 'socket', 'formula'}
-
-
-@pytest.fixture
-def power_report_with_nested_metadata(power_report_without_metadata) -> PowerReport:
-    """
-    Generates a power report with nested metadata.
-    """
-    power_report_without_metadata.metadata = {
-        'scope': 'cpu',
-        'socket': 0,
-        'formula': '0000000000000000000000000000000000000000',
-        'k8s': {
-            'app.kubernetes.io/name': 'test',
-            'app.kubernetes.io/managed-by': 'pytest',
-            'helm.sh/chart': 'powerapi-pytest-1.0.0'
-        }
-    }
-    return power_report_without_metadata
-
-
-@pytest.fixture
-def power_report_with_nested_metadata_expected_tags(power_report_with_nested_metadata) -> set[str]:
-    """
-    Returns the expected tags for the power report with nested metadata.
-    """
-    return {'sensor', 'target', 'scope', 'socket', 'formula', 'k8s_app_kubernetes_io_name', 'k8s_app_kubernetes_io_managed_by', 'k8s_helm_sh_chart'}

--- a/tests/unit/report/test_report.py
+++ b/tests/unit/report/test_report.py
@@ -36,10 +36,10 @@ def test_creating_report_with_metadata():
     """
     Test creating a report with metadata.
     """
-    report = Report(datetime.now(), 'pytest', 'test', {'tag1': 1, 'tag2': {'2'}, 'tag3': '3'})
+    report = Report(datetime.now(), 'pytest', 'test', {'tag1': '1', 'tag2': '2', 'tag3': '3'})
 
-    assert report.metadata["tag1"] == 1
-    assert report.metadata["tag2"] == {'2'}
+    assert report.metadata["tag1"] == '1'
+    assert report.metadata["tag2"] == '2'
     assert report.metadata["tag3"] == '3'
 
 
@@ -66,29 +66,3 @@ def test_sanitize_tags_name():
     assert sanitized_tags['test-tag'] == 'test_tag'
     assert sanitized_tags['app.kubernetes.io/name'] == 'app_kubernetes_io_name'
     assert sanitized_tags['helm.sh/chart'] == 'helm_sh_chart'
-
-
-def test_flatten_metadata_dict():
-    """
-    Test flattening a report metadata dictionary.
-    """
-    report_metadata = {
-        'scope': 'cpu',
-        'socket': 0,
-        'formula': '13edcdfbd3743bec4002a092cb39fbff20a175eb',
-        'k8s': {
-            'app.kubernetes.io/name': 'test-flatten',
-            'app.kubernetes.io/instance': 'test-abcxyz',
-            'app.kubernetes.io/managed-by': 'pytest',
-            'helm.sh/chart': 'powerapi-pytest-1.0.0'
-        }
-    }
-    flattened_metadata = Report.flatten_tags(report_metadata, '/')
-
-    assert flattened_metadata['scope'] == 'cpu'
-    assert flattened_metadata['socket'] == 0
-    assert flattened_metadata['formula'] == '13edcdfbd3743bec4002a092cb39fbff20a175eb'
-    assert flattened_metadata['k8s/app.kubernetes.io/name'] == 'test-flatten'
-    assert flattened_metadata['k8s/app.kubernetes.io/instance'] == 'test-abcxyz'
-    assert flattened_metadata['k8s/app.kubernetes.io/managed-by'] == 'pytest'
-    assert flattened_metadata['k8s/helm.sh/chart'] == 'powerapi-pytest-1.0.0'


### PR DESCRIPTION
Use canonical metadata entries directly when exporting reports and align report types and tests with the string-only metadata contract.

BREAKING CHANGE: Report metadata values must be strings and nested metadata are not supported anymore.