### PR TITLE
refactor(database/prometheus): Encode missing tags as empty labels

### DIFF
--- a/src/powerapi/database/prometheus/codecs.py
+++ b/src/powerapi/database/prometheus/codecs.py
@@ -58,7 +58,7 @@ class PowerReportEncoder(ReportEncoder[PowerReport, PowerReportMetrics]):
 
     @staticmethod
     def encode(report: PowerReport, opts: EncoderOptions | None = None) -> PowerReportMetrics:
-        dynamic_tags = [report.metadata.get(tag_name, 'unknown') for tag_name in opts.dynamic_tags_name]
+        dynamic_tags = [report.metadata.get(tag_name, '') for tag_name in opts.dynamic_tags_name]
         labels = (report.sensor, report.target, *dynamic_tags)
         return PowerReportMetrics(labels, report.timestamp.timestamp(), report.power)
 


### PR DESCRIPTION
Use an empty label value when a configured tag is absent from PowerReport metadata instead of assigning the synthetic "unknown" value.

This aligns missing tags with Prometheus semantics and avoids conflating absent metadata with a legitimate "unknown" tag value.